### PR TITLE
Add `--minimal` decision-first CLI output mode

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -620,3 +620,36 @@ def test_cli_appends_tamper_evident_decision_journal(tmp_path):
     assert entries[0]["previous_chain_hash"] is None
     assert entries[1]["previous_chain_hash"] == entries[0]["chain_hash"]
     assert second["report"]["journal"]["previous_chain_hash"] == first["report"]["journal"]["chain_hash"]
+
+
+def test_cli_minimal_mode_prints_compact_output(tmp_path, capsys):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_sample_csv(str(data_dir), "AAPL", trend=0.3)
+
+    result = run(
+        parse_args(
+            [
+                "--tickers",
+                "AAPL",
+                "--days",
+                "20",
+                "--scenarios",
+                "100",
+                "--seed",
+                "123",
+                "--no-show",
+                "--no-plots",
+                "--offline-path",
+                str(data_dir),
+                "--offline-only",
+                "--minimal",
+            ]
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert not result["summaries"].empty
+    assert "AAPL: er=" in output
+    assert "Summary for AAPL" not in output
+    assert "PLAN" in output


### PR DESCRIPTION
### Motivation
- Provide a compact, decision-first terminal output mode to reduce noise for users who prefer minimalist/brutalist summaries. 
- Make it easy to scan per-ticker decisions and a short portfolio plan without changing report artefacts or file outputs.

### Description
- Added a new CLI flag `--minimal` in `build_parser()` to enable compact output. 
- Implemented `_print_ticker_summary` and `_print_portfolio_summary` helpers in `run()` to emit concise lines like `AAPL: er=... up=... var95=...` when `--minimal` is set. 
- Suppressed verbose tables (rankings and allocations) when `--minimal` is enabled while preserving the action plan printout (header becomes `PLAN` in minimal mode). 
- Added `test_cli_minimal_mode_prints_compact_output` to `tests/test_cli.py` to validate the compact output behavior and ensure existing report generation is unchanged.

### Testing
- Ran the test suite with `pytest -q` which passed: `65 passed`.
- The new test `test_cli_minimal_mode_prints_compact_output` executes and validates that compact output appears and verbose summary lines are not printed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40b8ac0e48330a4acabf8f5231be6)