### PR TITLE
Add prediction-market Monte Carlo model anchored to fundamental truth

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -27,7 +27,12 @@ from analysis import (
     enforce_portfolio_risk_budget,
 )
 from data import PriceDataError, fetch_prices
-from simulation import estimate_gbm_parameters, simulate_gbm, simulate_prices
+from simulation import (
+    estimate_gbm_parameters,
+    simulate_gbm,
+    simulate_prediction_market,
+    simulate_prices,
+)
 from viz import plot_distribution, plot_paths
 
 LOGGER = logging.getLogger(__name__)
@@ -169,9 +174,54 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--model",
-        choices=("historical", "gbm"),
+        choices=("historical", "gbm", "prediction_market"),
         default="historical",
-        help="Simulation model: empirical distribution or geometric Brownian motion.",
+        help=(
+            "Simulation model: empirical historical bootstrap, geometric Brownian "
+            "motion, or prediction-market probabilities."
+        ),
+    )
+    parser.add_argument(
+        "--fundamental-probability",
+        type=float,
+        default=None,
+        help=(
+            "Required for --model prediction_market. Fundamental truth prior "
+            "for event probability (0-1)."
+        ),
+    )
+    parser.add_argument(
+        "--market-price",
+        type=float,
+        default=None,
+        help=(
+            "Optional current market-implied probability used as starting price "
+            "for --model prediction_market (0-1)."
+        ),
+    )
+    parser.add_argument(
+        "--fundamental-certainty",
+        type=_positive_float,
+        default=100.0,
+        help=(
+            "Pseudo-count confidence in --fundamental-probability for "
+            "--model prediction_market (higher = tighter truth prior)."
+        ),
+    )
+    parser.add_argument(
+        "--prob-mean-reversion",
+        type=float,
+        default=0.2,
+        help=(
+            "Daily pull toward latent truth in --model prediction_market "
+            "(0 = random walk around current level)."
+        ),
+    )
+    parser.add_argument(
+        "--prob-daily-volatility",
+        type=float,
+        default=0.03,
+        help="Noise scale for --model prediction_market probability paths.",
     )
     parser.add_argument(
         "--start",
@@ -364,6 +414,17 @@ def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
         parser.error("--portfolio-risk-budget-pct must be non-negative")
     if float(args.annual_cash_yield) < 0:
         parser.error("--annual-cash-yield must be non-negative")
+    if float(args.prob_mean_reversion) < 0:
+        parser.error("--prob-mean-reversion must be non-negative")
+    if float(args.prob_daily_volatility) < 0:
+        parser.error("--prob-daily-volatility must be non-negative")
+    if args.model == "prediction_market":
+        if args.fundamental_probability is None:
+            parser.error("--fundamental-probability is required for --model prediction_market")
+        if not 0.0 < float(args.fundamental_probability) < 1.0:
+            parser.error("--fundamental-probability must be strictly between 0 and 1")
+        if args.market_price is not None and not 0.0 < float(args.market_price) < 1.0:
+            parser.error("--market-price must be strictly between 0 and 1")
     return args
 
 
@@ -555,31 +616,39 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         print(summary.to_frame(name="value").to_string(float_format=lambda v: f"{v:0.2f}"))
 
     for ticker in tickers:
-        try:
-            prices = fetch_prices(
-                ticker,
-                start=args.start,
-                end=args.end,
-                offline_path=offline_path,
-                prefer_local=args.offline_only,
-                cache_dir=cache_dir,
-                refresh_cache=args.refresh_cache,
+        if args.model == "prediction_market":
+            current_price = float(
+                args.market_price
+                if args.market_price is not None
+                else args.fundamental_probability
             )
-        except PriceDataError as exc:
-            message = str(exc)
-            LOGGER.warning("[%s] %s", ticker, message)
-            errors.append({"ticker": ticker, "error": message})
-            continue
+            returns = pd.Series(dtype=float)
+        else:
+            try:
+                prices = fetch_prices(
+                    ticker,
+                    start=args.start,
+                    end=args.end,
+                    offline_path=offline_path,
+                    prefer_local=args.offline_only,
+                    cache_dir=cache_dir,
+                    refresh_cache=args.refresh_cache,
+                )
+            except PriceDataError as exc:
+                message = str(exc)
+                LOGGER.warning("[%s] %s", ticker, message)
+                errors.append({"ticker": ticker, "error": message})
+                continue
 
-        prices = prices.dropna()
-        returns = prices.pct_change().dropna()
-        if returns.empty:
-            message = "Not enough return data to run a simulation."
-            LOGGER.warning("[%s] %s", ticker, message)
-            errors.append({"ticker": ticker, "error": message})
-            continue
+            prices = prices.dropna()
+            returns = prices.pct_change().dropna()
+            if returns.empty:
+                message = "Not enough return data to run a simulation."
+                LOGGER.warning("[%s] %s", ticker, message)
+                errors.append({"ticker": ticker, "error": message})
+                continue
 
-        current_price = float(prices.iloc[-1])
+            current_price = float(prices.iloc[-1])
         current_prices[ticker] = current_price
         ticker_seed = (
             None
@@ -598,7 +667,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
                 shock_return=float(args.shock_return),
                 block_size=int(args.block_size),
             )
-        else:
+        elif args.model == "gbm":
             mu, sigma = estimate_gbm_parameters(returns)
             sims = simulate_gbm(
                 current_price=current_price,
@@ -610,6 +679,18 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
                 seed=ticker_seed,
                 shock_probability=float(args.shock_probability),
                 shock_return=float(args.shock_return),
+            )
+        else:
+            sims = simulate_prediction_market(
+                fundamental_probability=float(args.fundamental_probability),
+                current_price=float(current_price),
+                days=args.days,
+                scenarios=args.scenarios,
+                certainty=float(args.fundamental_certainty),
+                mean_reversion=float(args.prob_mean_reversion),
+                daily_volatility=float(args.prob_daily_volatility),
+                dt=args.dt,
+                seed=ticker_seed,
             )
 
         sims = sims.copy()

--- a/simulation.py
+++ b/simulation.py
@@ -7,7 +7,12 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
-__all__ = ["estimate_gbm_parameters", "simulate_prices", "simulate_gbm"]
+__all__ = [
+    "estimate_gbm_parameters",
+    "simulate_prices",
+    "simulate_gbm",
+    "simulate_prediction_market",
+]
 
 
 def _validate_shock_inputs(shock_probability: float, shock_return: float) -> None:
@@ -231,3 +236,58 @@ def simulate_gbm(
     index = pd.RangeIndex(start=1, stop=days + 1, name="day")
     columns = pd.RangeIndex(start=1, stop=scenarios + 1, name="scenario")
     return pd.DataFrame(cumulative, index=index, columns=columns)
+
+
+def simulate_prediction_market(
+    *,
+    fundamental_probability: float,
+    days: int,
+    scenarios: int,
+    current_price: float | None = None,
+    certainty: float = 100.0,
+    mean_reversion: float = 0.2,
+    daily_volatility: float = 0.03,
+    dt: float = 1.0,
+    seed: Optional[int] = None,
+) -> pd.DataFrame:
+    """Simulate prediction-market prices anchored to a fundamental truth prior."""
+
+    if days <= 0 or scenarios <= 0:
+        raise ValueError("days and scenarios must be positive integers")
+    if dt <= 0:
+        raise ValueError("dt must be positive")
+    if not 0.0 < fundamental_probability < 1.0:
+        raise ValueError("fundamental_probability must be strictly between 0 and 1")
+    if current_price is None:
+        current_price = fundamental_probability
+    if not 0.0 < current_price < 1.0:
+        raise ValueError("current_price must be strictly between 0 and 1")
+    if certainty <= 0:
+        raise ValueError("certainty must be positive")
+    if mean_reversion < 0:
+        raise ValueError("mean_reversion must be non-negative")
+    if daily_volatility < 0:
+        raise ValueError("daily_volatility must be non-negative")
+
+    alpha = fundamental_probability * certainty
+    beta = (1.0 - fundamental_probability) * certainty
+
+    rng = np.random.default_rng(seed)
+    latent_truth = rng.beta(alpha, beta, size=scenarios)
+
+    paths = np.empty((days, scenarios), dtype=float)
+    paths[0, :] = current_price
+
+    vol_scale = daily_volatility * np.sqrt(dt)
+    reversion_step = mean_reversion * dt
+    for day in range(1, days):
+        previous = paths[day - 1, :]
+        drift = reversion_step * (latent_truth - previous)
+        bounded_vol = vol_scale * np.sqrt(np.maximum(previous * (1.0 - previous), 1e-9))
+        innovation = rng.normal(loc=0.0, scale=bounded_vol, size=scenarios)
+        updated = previous + drift + innovation
+        paths[day, :] = np.clip(updated, 1e-4, 1.0 - 1e-4)
+
+    index = pd.RangeIndex(start=1, stop=days + 1, name="day")
+    columns = pd.RangeIndex(start=1, stop=scenarios + 1, name="scenario")
+    return pd.DataFrame(paths, index=index, columns=columns)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -653,3 +653,41 @@ def test_cli_minimal_mode_prints_compact_output(tmp_path, capsys):
     assert "AAPL: er=" in output
     assert "Summary for AAPL" not in output
     assert "PLAN" in output
+
+
+def test_cli_prediction_market_runs_without_price_data(tmp_path):
+    output_dir = tmp_path / "out"
+
+    result = run(
+        parse_args(
+            [
+                "--tickers",
+                "ELECTION_2028",
+                "--model",
+                "prediction_market",
+                "--fundamental-probability",
+                "0.64",
+                "--market-price",
+                "0.52",
+                "--days",
+                "30",
+                "--scenarios",
+                "300",
+                "--seed",
+                "42",
+                "--no-show",
+                "--no-plots",
+                "--output",
+                str(output_dir),
+            ]
+        )
+    )
+
+    summary = result["report"]["results"]["ELECTION_2028"]["summary"]
+    assert summary["mean"] > 0
+    assert result["simulations"].shape == (30, 300)
+
+
+def test_cli_prediction_market_requires_fundamental_probability():
+    with pytest.raises(SystemExit):
+        parse_args(["--model", "prediction_market"])

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -117,3 +117,40 @@ def test_simulate_prices_rejects_invalid_block_size():
     returns = pd.Series([0.01, -0.02, 0.015])
     with pytest.raises(ValueError):
         simulate_prices(returns, days=10, scenarios=5, block_size=0)
+
+
+def test_simulate_prediction_market_is_bounded_and_reproducible():
+    from simulation import simulate_prediction_market
+
+    sims_a = simulate_prediction_market(
+        fundamental_probability=0.62,
+        current_price=0.55,
+        days=30,
+        scenarios=200,
+        certainty=120.0,
+        mean_reversion=0.25,
+        daily_volatility=0.04,
+        seed=123,
+    )
+    sims_b = simulate_prediction_market(
+        fundamental_probability=0.62,
+        current_price=0.55,
+        days=30,
+        scenarios=200,
+        certainty=120.0,
+        mean_reversion=0.25,
+        daily_volatility=0.04,
+        seed=123,
+    )
+
+    assert sims_a.equals(sims_b)
+    assert sims_a.shape == (30, 200)
+    assert sims_a.to_numpy().min() > 0.0
+    assert sims_a.to_numpy().max() < 1.0
+
+
+def test_simulate_prediction_market_rejects_out_of_range_probability():
+    from simulation import simulate_prediction_market
+
+    with pytest.raises(ValueError):
+        simulate_prediction_market(fundamental_probability=1.0, days=10, scenarios=5)


### PR DESCRIPTION
### Motivation

- Provide a principled Monte Carlo engine for binary-event prediction markets that is explicitly tied to a latent fundamental truth instead of reusing stock price models.
- Allow simulations for event probabilities (bounded 0–1) with configurable prior confidence and dynamics so decision logic and portfolio analytics can include political/election or other binary predictions.

### Description

- Added a new simulation function `simulate_prediction_market` in `simulation.py` that samples a latent truth per scenario from a Beta prior (centered on `fundamental_probability` with pseudo-count `certainty`) and evolves bounded probability paths via mean reversion + Gaussian innovations; outputs are clipped to remain in `(0,1)`.
- Exposed the new model in the CLI by adding `--model prediction_market` and prediction-market specific flags: `--fundamental-probability`, `--market-price`, `--fundamental-certainty`, `--prob-mean-reversion`, and `--prob-daily-volatility`, with argument validation in `parse_args`.
- Updated runtime flow in `cli.py` so `prediction_market` runs do not attempt historical price fetches and instead simulate directly from the supplied fundamental inputs while preserving existing `historical` and `gbm` behaviors.
- Added tests: new unit tests for `simulate_prediction_market` in `tests/test_simulation.py` (reproducibility, bounded outputs, invalid input) and CLI tests in `tests/test_cli.py` (runs without price data and required-argument enforcement).

### Testing

- Ran targeted tests with `pytest tests/test_simulation.py tests/test_cli.py` which passed: `33 passed`.
- Ran full suite with `pytest` which passed: `69 passed`.
- All newly added tests for the prediction-market model and CLI validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c73372f48330b6a3b82dd1e9496e)