### PR TITLE
Harden simulation CLI contracts and error reporting

### DIFF
--- a/public_cli.py
+++ b/public_cli.py
@@ -12,6 +12,7 @@ from typing import Any, Iterable, Optional
 import pandas as pd
 
 import backtest as backtest_cli
+from data import PriceDataError
 from cli_shared import (
     IntentionalDefaultsHelpFormatter,
     non_negative_int,
@@ -317,6 +318,64 @@ def describe_price_sources(price_sources: object) -> str | None:
     return "Data source: " + "; ".join(parts) + "."
 
 
+def _log_public_error(exc: Exception, *, command: str, args: argparse.Namespace) -> None:
+    """Emit actionable, command-specific errors for terminal operators."""
+
+    if isinstance(exc, PriceDataError):
+        source = str(getattr(args, "source", "auto"))
+        data_path = str(getattr(args, "data_path", "sample_data") or "sample_data")
+        LOGGER.error(
+            "Couldn't complete %s because price data could not be loaded: %s",
+            command,
+            exc,
+        )
+
+        if source == "online":
+            LOGGER.error(
+                "Try `--source auto` for local fallback, or `--source offline --data-path %s` "
+                "for offline/CSV mode.",
+                data_path,
+            )
+        else:
+            LOGGER.error(
+                "Tip: check `--data-path` points to a CSV file or a folder of <TICKER>.csv "
+                "files, or use `--source offline --data-path sample_data` for bundled fixtures.",
+            )
+        return
+
+    if isinstance(exc, ValueError):
+        LOGGER.error("Invalid input for %s: %s", command, exc)
+        LOGGER.error("Use `%s --help` to check valid flags and defaults.", command)
+        return
+
+    LOGGER.error("%s", exc)
+
+
+def _log_no_simulation_output(
+    *,
+    args: argparse.Namespace,
+    result: dict[str, Any],
+) -> None:
+    """Log a clear message when no ticker finished simulation."""
+
+    report = result.get("report", {})
+    errors = report.get("errors", []) if isinstance(report, dict) else []
+    if errors:
+        LOGGER.error(
+            "No simulations were produced for %s.",
+            ", ".join(str(ticker) for ticker in args.tickers),
+        )
+        for item in errors:
+            if not isinstance(item, dict):
+                continue
+            ticker = str(item.get("ticker", "unknown"))
+            message = str(item.get("error", "Unknown error"))
+            LOGGER.error("  %s: %s", ticker, message)
+        return
+
+    LOGGER.error("No simulations were produced. Try loosening filters or check input history.")
+
+
 def _price_source_details(price_sources: object) -> list[str]:
     normalized = _normalize_price_sources(price_sources)
     details: list[str] = []
@@ -512,12 +571,15 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
     try:
         if args.command == "simulate":
             result = run_public_simulate(args)
-            return 0 if not result["summaries"].empty else 1
+            if result["summaries"].empty:
+                _log_no_simulation_output(args=args, result=result)
+                return 1
+            return 0
         if args.command == "backtest":
             run_public_backtest(args)
             return 0
     except Exception as exc:
-        LOGGER.error("%s", exc)
+        _log_public_error(exc, command=str(args.command), args=args)
         return 2
 
     return 2

--- a/simulate_cli.py
+++ b/simulate_cli.py
@@ -297,11 +297,14 @@ def maybe_show_simulation_plots(args: argparse.Namespace, result: dict[str, Any]
 def run(
     args: argparse.Namespace,
     *,
-    render: bool = True,
+    render: bool = False,
     display_plots: bool = True,
     renderer: Callable[[dict[str, Any], argparse.Namespace], None] | None = None,
 ) -> dict[str, Any]:
     """Execute the simulation workflow and return simulation artefacts."""
+
+    if render and renderer is None:
+        raise ValueError("renderer is required when render=True")
 
     tickers = _normalise_tickers(args.tickers)
     output_dir = Path(args.output).expanduser() if args.output else None
@@ -595,8 +598,6 @@ def run(
     }
 
     if render:
-        if renderer is None:
-            raise ValueError("renderer is required when render=True")
         renderer(result, args)
     if display_plots:
         maybe_show_simulation_plots(args, result)

--- a/simulate_cli.py
+++ b/simulate_cli.py
@@ -298,10 +298,17 @@ def run(
     args: argparse.Namespace,
     *,
     render: bool = False,
-    display_plots: bool = True,
+    display_plots: bool = False,
     renderer: Callable[[dict[str, Any], argparse.Namespace], None] | None = None,
 ) -> dict[str, Any]:
-    """Execute the simulation workflow and return simulation artefacts."""
+    """Execute the simulation workflow and return simulation artefacts.
+
+    Plot display is opt-in: ``display_plots`` defaults to ``False`` so that
+    programmatic callers using :func:`build_simulation_args` defaults
+    (which set ``show=True``) do not unexpectedly open or block on GUI plot
+    windows. CLI entry points pass ``display_plots=True`` explicitly when an
+    interactive session is desired.
+    """
 
     if render and renderer is None:
         raise ValueError("renderer is required when render=True")

--- a/simulation.py
+++ b/simulation.py
@@ -50,7 +50,9 @@ def estimate_gbm_parameters(returns: pd.Series) -> tuple[float, float]:
 
     values = cleaned.to_numpy(dtype=float)
     if values.size < 2:
-        raise ValueError("returns must contain at least two observations to estimate GBM volatility")
+        raise ValueError(
+            "returns must contain at least two observations to estimate GBM volatility"
+        )
     if not np.isfinite(values).all():
         raise ValueError("returns must contain only finite values")
     if (values <= -1.0).any():

--- a/simulation.py
+++ b/simulation.py
@@ -49,6 +49,8 @@ def estimate_gbm_parameters(returns: pd.Series) -> tuple[float, float]:
         raise ValueError("returns must contain at least one numeric observation")
 
     values = cleaned.to_numpy(dtype=float)
+    if values.size < 2:
+        raise ValueError("returns must contain at least two observations to estimate GBM volatility")
     if not np.isfinite(values).all():
         raise ValueError("returns must contain only finite values")
     if (values <= -1.0).any():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ import backtest as backtest_module  # noqa: E402
 import cli as cli_module  # noqa: E402
 import data  # noqa: E402
 import MonteCarlo  # noqa: E402
+import simulate_cli  # noqa: E402
 from cli import legacy_main, parse_args, run  # noqa: E402
 from public_cli import (  # noqa: E402
     main,
@@ -257,6 +258,35 @@ def test_public_simulate_matches_legacy_core_outputs(tmp_path, capsys):
     assert set(public["report"]["rankings"]) == set(legacy["report"]["rankings"])
     assert public["report"]["action_plan"]["stance"] == legacy["report"]["action_plan"]["stance"]
     assert public["report"]["portfolio_summary"] == legacy["report"]["portfolio_summary"]
+
+
+def test_simulate_cli_run_defaults_to_headless_programmatic_mode(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_sample_csv(str(data_dir), "AAPL", trend=0.5)
+
+    args = simulate_cli.build_simulation_args(
+        tickers="AAPL",
+        days=5,
+        scenarios=10,
+        seed=7,
+        offline_path=str(data_dir),
+        offline_only=True,
+        show=False,
+        no_plots=True,
+    )
+
+    result = simulate_cli.run(args)
+
+    assert not result["summaries"].empty
+    assert list(result["summaries"].index) == ["AAPL"]
+
+
+def test_simulate_cli_run_requires_renderer_when_rendering():
+    args = simulate_cli.build_simulation_args()
+
+    with pytest.raises(ValueError, match="renderer is required when render=True"):
+        simulate_cli.run(args, render=True)
 
 
 def test_public_backtest_matches_legacy_summary(tmp_path, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -319,6 +319,30 @@ def test_simulate_cli_run_requires_renderer_when_rendering():
         simulate_cli.run(args, render=True)
 
 
+def test_simulate_cli_run_does_not_display_plots_with_default_args(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    _write_sample_csv(str(data_dir), "AAPL", trend=0.5)
+
+    show_calls: list[None] = []
+    monkeypatch.setattr(
+        "simulate_cli.plt.show", lambda *args, **kwargs: show_calls.append(None)
+    )
+
+    args = simulate_cli.build_simulation_args(
+        tickers="AAPL",
+        days=5,
+        scenarios=10,
+        seed=7,
+        offline_path=str(data_dir),
+        offline_only=True,
+    )
+
+    simulate_cli.run(args)
+
+    assert show_calls == []
+
+
 def test_public_backtest_matches_legacy_summary(tmp_path, capsys):
     data_dir = tmp_path / "data"
     data_dir.mkdir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -50,6 +51,35 @@ def test_public_main_without_subcommand_prints_help_hint(capsys):
 def test_public_parse_args_rejects_unknown_source():
     with pytest.raises(SystemExit):
         parse_public_args(["simulate", "AAPL", "--source", "sideways"])
+
+
+def test_public_simulate_reports_no_valid_results_for_failing_tickers(monkeypatch, caplog):
+    def _fetch(_ticker, *args, **kwargs):
+        raise data.PriceDataError("network unavailable")
+
+    monkeypatch.setattr(simulate_cli, "fetch_prices", _fetch)
+
+    with caplog.at_level(logging.ERROR, logger="public_cli"):
+        exit_code = main(
+            [
+                "simulate",
+                "AAPL",
+                "MSFT",
+                "--source",
+                "online",
+                "--days",
+                "5",
+                "--scenarios",
+                "10",
+            ]
+        )
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+
+    assert exit_code == 1
+    assert "No simulations were produced for AAPL, MSFT." in messages
+    assert "AAPL: network unavailable" in messages
+    assert "MSFT: network unavailable" in messages
 
 
 @pytest.mark.parametrize("argv", [["simulate", "--help"], ["backtest", "--help"]])

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -69,6 +69,11 @@ def test_estimate_gbm_parameters_produces_valid_inputs():
     assert paths.shape == (5, 3)
 
 
+def test_estimate_gbm_parameters_requires_two_observations():
+    with pytest.raises(ValueError, match="at least two observations"):
+        estimate_gbm_parameters(pd.Series([0.01]))
+
+
 def test_simulate_prices_rejects_invalid_dt():
     returns = pd.Series([0.01, -0.02, 0.015])
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Make `simulate_cli.run()` headless by default and fail fast when `render=True` is requested without a renderer.
- Reject GBM parameter estimation from fewer than two return observations.
- Surface command-specific guidance from the public CLI on `PriceDataError` / `ValueError`, exit `1` (not silent) when every ticker fails, and log per-ticker errors so operators can recover.
- Refresh `CLAUDE.md` to reflect the current module surface (decision layer, AI summaries, browser UI, output artifacts, CI workflows).
- Add regression tests for the renderer contract, the GBM 2-observation minimum, and the no-results error path.

## Test plan
- [x] `pytest -q` — 128 passed, 1 skipped (Flask install-detection test).
- [x] `flake8 public_cli.py simulate_cli.py simulation.py tests/test_cli.py tests/test_simulation.py` — clean.
- [x] Confirmed the existing `test_public_simulate_reports_missing_offline_data` path still asserts exit `1` with actionable `--data-path` guidance.