### PR TITLE
Add path-aware allocation portfolio risk and reporting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Monte Carlo local runtime defaults.
+# Copy to .env only if your launcher loads dotenv files; the app reads these
+# values from the process environment and never requires secrets for offline runs.
+
+# Browser UI bind address. Keep localhost for local development.
+HOST=127.0.0.1
+PORT=8000
+
+# Headless plotting default for CI, servers, and terminals without a display.
+MPLBACKEND=Agg
+
+# Optional AI summaries. Leave blank unless you run with --ai-summary.
+OPENAI_API_KEY=
+OPENAI_BASE_URL=https://api.openai.com/v1

--- a/analysis.py
+++ b/analysis.py
@@ -147,14 +147,21 @@ def summarize_final_prices(
     return pd.Series(summary)
 
 
-def summarize_equal_weight_portfolio(
+def summarize_weighted_portfolio(
     simulations: pd.DataFrame,
     *,
     current_prices: Mapping[str, float],
+    weights: Mapping[str, float] | pd.Series,
     quantiles: Sequence[float] | None = None,
     benchmark_return_pct: float | None = None,
 ) -> pd.Series:
-    """Return summary statistics for an equal-weight portfolio."""
+    """Return path-aware summary statistics for a weighted portfolio.
+
+    The portfolio starts at ``1.0``. Supplied weights are invested weights; any
+    unused capital stays in cash at ``1.0`` for the simulated horizon. Scenario
+    columns are matched by scenario id across tickers, preserving the simulated
+    cross-name outcomes instead of adding standalone VaR numbers together.
+    """
 
     if simulations.empty:
         raise ValueError("simulations must contain scenario paths")
@@ -177,13 +184,21 @@ def summarize_equal_weight_portfolio(
     if (initial_prices <= 0).any():
         raise ValueError("all current prices must be positive")
 
-    weights = pd.Series(1.0 / len(tickers), index=tickers, dtype=float)
+    weight_series = pd.Series(weights, dtype=float).reindex(tickers).fillna(0.0)
+    if (weight_series < 0).any():
+        raise ValueError("portfolio weights must be non-negative")
+    if float(weight_series.sum()) > 1.0 + 1e-9:
+        raise ValueError("portfolio weights cannot sum above 1.0")
+
+    cash_weight = max(0.0, 1.0 - float(weight_series.sum()))
     scenarios = simulations.columns.get_level_values("scenario").unique()
     portfolio_columns: dict[object, pd.Series] = {}
     for scenario in scenarios:
         scenario_frame = simulations.xs(scenario, axis=1, level="scenario")
         normalized = scenario_frame.div(initial_prices, axis="columns")
-        portfolio_columns[scenario] = normalized.mul(weights, axis="columns").sum(axis=1)
+        portfolio_columns[scenario] = (
+            normalized.mul(weight_series, axis="columns").sum(axis=1) + cash_weight
+        )
 
     portfolio_paths = pd.DataFrame(portfolio_columns, index=simulations.index)
     portfolio_paths.columns.name = "scenario"
@@ -193,11 +208,42 @@ def summarize_equal_weight_portfolio(
         quantiles=quantiles,
         benchmark_return_pct=benchmark_return_pct,
     )
-    summary["component_count"] = float(len(tickers))
+    summary["component_count"] = float((weight_series > 0).sum())
+    summary["invested_weight"] = float(weight_series.sum())
+    summary["cash_weight"] = float(cash_weight)
     return summary
+
+
+def summarize_equal_weight_portfolio(
+    simulations: pd.DataFrame,
+    *,
+    current_prices: Mapping[str, float],
+    quantiles: Sequence[float] | None = None,
+    benchmark_return_pct: float | None = None,
+) -> pd.Series:
+    """Return summary statistics for an equal-weight portfolio."""
+
+    if simulations.empty:
+        raise ValueError("simulations must contain scenario paths")
+    if not isinstance(simulations.columns, pd.MultiIndex):
+        raise ValueError("simulations must use a ticker/scenario MultiIndex")
+
+    tickers = list(simulations.columns.get_level_values("ticker").unique())
+    if not tickers:
+        raise ValueError("simulations must include at least one ticker")
+
+    weights = pd.Series(1.0 / len(tickers), index=tickers, dtype=float)
+    return summarize_weighted_portfolio(
+        simulations,
+        current_prices=current_prices,
+        weights=weights,
+        quantiles=quantiles,
+        benchmark_return_pct=benchmark_return_pct,
+    )
 
 
 __all__ = [
     "summarize_final_prices",
     "summarize_equal_weight_portfolio",
+    "summarize_weighted_portfolio",
 ]

--- a/decision.py
+++ b/decision.py
@@ -148,13 +148,22 @@ def enforce_portfolio_risk_budget(
     rankings: pd.DataFrame,
     *,
     max_portfolio_var_95_pct: float,
+    portfolio_var_95_pct: float | None = None,
 ) -> pd.DataFrame:
-    """Scale allocations so blended 95% VaR stays within a hard budget."""
+    """Scale allocations so portfolio 95% VaR stays within a hard budget.
+
+    When ``portfolio_var_95_pct`` is supplied, the guard uses path-aware
+    simulated portfolio VaR without allowing it to understate the conservative
+    standalone ticker VaR blend. Otherwise it falls back to the standalone
+    blend. Scaling is linear because the excess exposure is moved to cash.
+    """
 
     if allocations.empty:
         return allocations.copy()
     if max_portfolio_var_95_pct < 0:
         raise ValueError("max_portfolio_var_95_pct must be non-negative")
+    if portfolio_var_95_pct is not None and portfolio_var_95_pct < 0:
+        raise ValueError("portfolio_var_95_pct must be non-negative when provided")
     if "weight" not in allocations.columns:
         raise ValueError("allocations missing required columns: weight")
     if "value_at_risk_95_pct" not in rankings.columns:
@@ -163,10 +172,15 @@ def enforce_portfolio_risk_budget(
     scoped = allocations.copy()
     scoped_var = rankings.reindex(scoped.index)["value_at_risk_95_pct"].fillna(0.0)
     blended_var = float((scoped["weight"] * scoped_var).sum())
-    if blended_var <= max_portfolio_var_95_pct or blended_var <= 0.0:
+    if portfolio_var_95_pct is None:
+        budget_var = blended_var
+    else:
+        budget_var = max(float(portfolio_var_95_pct), blended_var)
+
+    if budget_var <= max_portfolio_var_95_pct or budget_var <= 0.0:
         return scoped
 
-    scale = max_portfolio_var_95_pct / blended_var
+    scale = max_portfolio_var_95_pct / budget_var
     scoped["weight"] = scoped["weight"] * scale
     return scoped
 

--- a/docs/output-guide.md
+++ b/docs/output-guide.md
@@ -24,9 +24,11 @@ Open these first:
 
 - `action_plan.md` is the shortest human-readable decision.
 - `report.json` is the full machine-readable record, including inputs, rankings,
-  allocations, errors, and `price_sources`.
+  allocations, path-aware allocation portfolio risk, errors, and `price_sources`.
 - `rankings.csv` is the scored list of tickers after the model and guardrails.
-- `allocations.csv` is the suggested weight for the names that survived.
+- `allocations.csv` is the suggested weight for the names that survived. The
+  matching `allocation_portfolio_summary` in `report.json` measures the
+  simulated portfolio after cash buffers and risk-budget scaling.
 - `summaries.csv` and `summaries.json` are the per-ticker simulation stats.
 - `*_distribution.png` and `*_paths.png` are the fastest visual check for shape,
   spread, and downside.

--- a/simulate_cli.py
+++ b/simulate_cli.py
@@ -15,7 +15,11 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 from ai import OpenAIConfigurationError, OpenAIRequestError, generate_ai_summary
-from analysis import summarize_equal_weight_portfolio, summarize_final_prices
+from analysis import (
+    summarize_equal_weight_portfolio,
+    summarize_final_prices,
+    summarize_weighted_portfolio,
+)
 from data import PriceDataError, fetch_prices, get_price_source
 from decision import (
     apply_risk_guards,
@@ -478,7 +482,29 @@ def run(
         else rankings
     )
     allocations = recommend_allocations(rankings) if not rankings.empty else pd.DataFrame()
-    if not allocations.empty:
+    allocation_portfolio_summary: pd.Series | None = None
+    if not allocations.empty and not combined.empty:
+        allocation_portfolio_summary = summarize_weighted_portfolio(
+            combined,
+            current_prices=current_prices,
+            weights=allocations["weight"],
+            benchmark_return_pct=benchmark_return_pct,
+        )
+        allocations = enforce_portfolio_risk_budget(
+            allocations,
+            rankings,
+            max_portfolio_var_95_pct=float(args.portfolio_risk_budget_pct),
+            portfolio_var_95_pct=float(
+                allocation_portfolio_summary.get("value_at_risk_95_pct", 0.0)
+            ),
+        )
+        allocation_portfolio_summary = summarize_weighted_portfolio(
+            combined,
+            current_prices=current_prices,
+            weights=allocations["weight"],
+            benchmark_return_pct=benchmark_return_pct,
+        )
+    elif not allocations.empty:
         allocations = enforce_portfolio_risk_budget(
             allocations,
             rankings,
@@ -516,6 +542,11 @@ def run(
         },
         "portfolio_summary": (
             portfolio_summary.to_dict() if portfolio_summary is not None else None
+        ),
+        "allocation_portfolio_summary": (
+            allocation_portfolio_summary.to_dict()
+            if allocation_portfolio_summary is not None
+            else None
         ),
         "rankings": rankings.to_dict(orient="index") if not rankings.empty else {},
         "allocations": allocations.to_dict(orient="index") if not allocations.empty else {},

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -4,7 +4,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from analysis import summarize_equal_weight_portfolio, summarize_final_prices
+from analysis import (
+    summarize_equal_weight_portfolio,
+    summarize_final_prices,
+    summarize_weighted_portfolio,
+)
 
 
 def test_summarize_final_prices_reports_key_metrics():
@@ -110,6 +114,41 @@ def test_summarize_equal_weight_portfolio_combines_tickers():
     assert summary["component_count"] == 2.0
     assert summary["mean"] == pytest.approx(1.1)
     assert summary["expected_return"] == pytest.approx(0.1)
+
+
+def test_summarize_weighted_portfolio_keeps_uninvested_cash_stable():
+    sims = pd.DataFrame(
+        {
+            ("AAPL", 0): [100.0, 80.0],
+            ("AAPL", 1): [100.0, 120.0],
+            ("MSFT", 0): [50.0, 50.0],
+            ("MSFT", 1): [50.0, 60.0],
+        }
+    )
+    sims.columns = pd.MultiIndex.from_tuples(sims.columns, names=["ticker", "scenario"])
+
+    summary = summarize_weighted_portfolio(
+        sims,
+        current_prices={"AAPL": 100.0, "MSFT": 50.0},
+        weights={"AAPL": 0.25, "MSFT": 0.25},
+    )
+
+    assert summary["invested_weight"] == pytest.approx(0.5)
+    assert summary["cash_weight"] == pytest.approx(0.5)
+    assert summary["component_count"] == pytest.approx(2.0)
+    assert summary["mean"] == pytest.approx(1.025)
+
+
+def test_summarize_weighted_portfolio_rejects_leverage():
+    sims = pd.DataFrame({("AAPL", 0): [100.0, 101.0]})
+    sims.columns = pd.MultiIndex.from_tuples(sims.columns, names=["ticker", "scenario"])
+
+    with pytest.raises(ValueError, match="cannot sum above 1.0"):
+        summarize_weighted_portfolio(
+            sims,
+            current_prices={"AAPL": 100.0},
+            weights={"AAPL": 1.2},
+        )
 
 
 def test_summarize_equal_weight_portfolio_uses_full_paths_for_drawdown_metrics():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -418,6 +418,10 @@ def test_cli_runs_multi_ticker(tmp_path):
     assert set(result["report"]["rankings"]) == {"AAPL", "MSFT"}
     assert "max_drawdown_q95" in result["report"]["rankings"]["AAPL"]
     assert result["report"]["allocations"]
+    assert result["report"]["allocation_portfolio_summary"] is not None
+    assert result["report"]["allocation_portfolio_summary"]["invested_weight"] == pytest.approx(
+        sum(item["weight"] for item in result["report"]["allocations"].values())
+    )
     assert result["report"]["action_plan"]["stance"] in {"RISK_ON", "SELECTIVE", "DEFENSIVE"}
     assert (output_dir / "rankings.csv").exists()
     assert (output_dir / "allocations.csv").exists()

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -296,6 +296,29 @@ def test_enforce_portfolio_risk_budget_scales_weights_when_budget_exceeded():
     assert constrained["weight"].sum() < allocations["weight"].sum()
 
 
+def test_enforce_portfolio_risk_budget_uses_path_aware_var_when_supplied():
+    rankings = pd.DataFrame(
+        {
+            "value_at_risk_95_pct": {"AAPL": 0.05, "MSFT": 0.05},
+        }
+    )
+    allocations = pd.DataFrame(
+        {
+            "weight": {"AAPL": 0.5, "MSFT": 0.5},
+        }
+    )
+
+    constrained = enforce_portfolio_risk_budget(
+        allocations,
+        rankings,
+        max_portfolio_var_95_pct=0.08,
+        portfolio_var_95_pct=0.10,
+    )
+
+    assert constrained["weight"].sum() == pytest.approx(0.8)
+    assert constrained.loc["AAPL", "weight"] == pytest.approx(0.4)
+
+
 def test_enforce_portfolio_risk_budget_keeps_weights_when_under_budget():
     rankings = pd.DataFrame(
         {


### PR DESCRIPTION
### Motivation
- Ensure allocation-level risk is measured using the actual simulated portfolio paths (not just a naive blend of per-ticker VaR) so the risk-budget guard scales allocations more reasonably while never understating conservative standalone VaR. 
- Surface the allocation-level portfolio summary in the simulation report and document the output so downstream audit and execution can consume path-aware metrics.

### Description
- Add `summarize_weighted_portfolio` to `analysis.py` to compute path-aware portfolio paths given arbitrary invested weights, explicitly report `invested_weight`, `cash_weight`, and path-aware VaR/drawdown metrics, and keep a compatibility wrapper `summarize_equal_weight_portfolio`.
- Extend `enforce_portfolio_risk_budget` in `decision.py` to accept an optional `portfolio_var_95_pct` and use `max(portfolio_var_95_pct, blended_standalone_var)` as the budget basis, then scale allocations linearly to meet the `max_portfolio_var_95_pct` constraint.
- Wire the new summary into the simulation workflow in `simulate_cli.py` by computing an `allocation_portfolio_summary`, passing its `value_at_risk_95_pct` into the guard, and persisting `allocation_portfolio_summary` inside the top-level `report` JSON; update `docs/output-guide.md` to describe the new field.
- Add `.env.example` for sensible local defaults (host, port, `MPLBACKEND`, and optional OpenAI settings) and add focused tests and test updates for weighted-portfolio behavior and path-aware risk-budget handling.

### Testing
- Installed the package with `python3 -m pip install -e .` and ran the test subsets used during development: `pytest tests/test_analysis.py tests/test_decision.py tests/test_cli.py::test_cli_runs_multi_ticker tests/test_cli.py::test_cli_applies_portfolio_risk_budget_scaling -q` which exercised the new code paths.
- Ran the full suite with `pytest -q` after changes, producing `113 passed, 1 skipped`.
- All added/updated tests (weighted portfolio cash handling, leverage rejection, path-aware risk-budget scaling, and report persistence) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00941490088330918e3be145072674)