### PR TITLE
Make Claude code review CI manually invoked

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,23 +1,19 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - "**/*.py"
-      - "pyproject.toml"
-      - "requirements*.txt"
-      - "requirements.lock.txt"
-      - ".github/workflows/**"
-      - ".claude/commands/**"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review"
+        required: true
+        type: string
 
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
+  group: claude-review-${{ inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -31,13 +27,26 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Resolve PR head SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          sha=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)
+          if [ -z "$sha" ]; then
+            echo "Could not resolve head SHA for PR #$PR_NUMBER" >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
       - name: Claude profit-focused review
         id: review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
-          prompt: "/profit-review REPO: ${{ github.repository }} PR: ${{ github.event.pull_request.number }} SHA: ${{ github.event.pull_request.head.sha }}"
+          prompt: "/profit-review REPO: ${{ github.repository }} PR: ${{ inputs.pr_number }} SHA: ${{ steps.pr.outputs.sha }}"
           claude_args: |
             --model claude-opus-4-6
             --max-turns 8


### PR DESCRIPTION
## Summary
- Replace the automatic \`pull_request\` triggers on \`.github/workflows/claude-code-review.yml\` with a single \`workflow_dispatch\` entry that takes a \`pr_number\` input.
- Resolve the PR's head SHA at run time via \`gh pr view --json headRefOid\` so the existing \`/profit-review\` prompt continues to receive both \`PR\` and \`SHA\`.
- Keep the prompt, model, \`max-turns\`, and \`allowedTools\` allowlist unchanged.

## Why
The review check currently runs on every PR open/sync/reopen and burns Claude API budget on changes that don't need a profit-focused pass. Making it manual keeps the option available without auto-firing on every push.

## How to run after this lands
- GitHub UI: Actions → "Claude Code Review" → "Run workflow" → enter the PR number.
- CLI: \`gh workflow run claude-code-review.yml -f pr_number=<N>\`.

## Test plan
- [x] \`actionlint\`-style review of the YAML diff (no shell injection: \`pr_number\` is passed via \`env: PR_NUMBER\` and quoted in the shell step).
- [ ] Trigger the workflow manually against an open PR and confirm the review comment lands.