### PR TITLE
Cut CI checks from 10 to 2 per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,21 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  cli:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.12"]
 
     steps:
       - name: Checkout
@@ -22,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
-      - name: Install CLI dependencies
+      - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.lock.txt
@@ -34,6 +39,9 @@ jobs:
           import importlib.util
           assert importlib.util.find_spec("flask") is None
           PY
+
+      - name: Lint
+        run: flake8 .
 
       - name: Entrypoint smoke test
         env:
@@ -47,34 +55,17 @@ jobs:
           monte-carlo-ui > ui.out 2>&1 || test $? -eq 2
           grep -F "Install \`python3 -m pip install -e .[ui]\`" ui.out
 
-      - name: Lint
-        run: flake8 .
-
       - name: Tests
         env:
           MPLBACKEND: Agg
         run: pytest -q
 
-  ui:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install UI dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.lock.txt
-          python -m pip install -e .[dev,ui]
+      - name: Install UI extras
+        if: matrix.python-version == '3.12'
+        run: python -m pip install -e .[dev,ui]
 
       - name: Browser UI tests
+        if: matrix.python-version == '3.12'
         env:
           MPLBACKEND: Agg
         run: pytest tests/test_web_ui.py -q


### PR DESCRIPTION
## Summary
Every PR commit was spawning 10 status checks because three things were multiplying the runs:

1. `on: push:` and `on: pull_request:` both fired on every PR commit, doubling everything.
2. The Python matrix ran 4 versions (3.9, 3.10, 3.11, 3.12) when 3.10 and 3.11 add no signal between the oldest supported (3.9) and the current default (3.12).
3. A separate `ui` job spun up its own Python install just to run `tests/test_web_ui.py`.

## Changes
- Trigger on `pull_request` and `push: branches: [main]` only — PR branches stop double-firing, but main still gets a post-merge gate.
- Matrix down to `["3.9", "3.12"]`.
- Fold the UI job into the `test` job as a 3.12-only `pip install -e .[dev,ui]` + `pytest tests/test_web_ui.py` step. The `Verify Flask is not part of the base install` guard still runs first so the `[ui]` extra stays genuinely optional.
- Add a `concurrency` group so a new push to a PR cancels the in-flight run.

## Result
`cli (3.9), cli (3.10), cli (3.11), cli (3.12), ui` × push + pull_request → **`test (3.9), test (3.12)`**. 10 checks → 2.

## Test plan
- [ ] Confirm the workflow runs on this PR with exactly two checks (`test (3.9)`, `test (3.12)`) and both go green.
- [ ] After merge, confirm a fresh PR no longer produces duplicate runs from push + pull_request.