### PR TITLE
Refine browser UI and ship on Vercel

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,15 @@
+.venv/
+.pytest_cache/
+__pycache__/
+**/__pycache__/
+*.egg-info/
+docs/
+tests/
+output/
+results/
+.agent/
+.github/
+.claude/
+uv.lock
+requirements.lock.txt
+pyproject.toml

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,17 @@
+"""Vercel Python entrypoint — exposes the Flask app at every route."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import app  # noqa: E402
+
+__all__ = ["app"]

--- a/app.py
+++ b/app.py
@@ -77,15 +77,20 @@ PAGE_TEMPLATE = """
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Monte Carlo</title>
+    <meta name="color-scheme" content="dark">
+    <meta name="description"
+      content="Monte Carlo — a decision engine for current ideas and historical backtests.">
+    <title>Monte Carlo — Decision engine</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="/styles.css">
   </head>
   <body>
     <main class="shell">
       <header class="masthead">
         <div>
-          <p class="eyebrow">Monte Carlo</p>
-          <h1>Simulate current ideas or backtest history.</h1>
+          <p class="eyebrow">Monte&nbsp;Carlo</p>
+          <h1>Simulate current ideas, or backtest history.</h1>
           <p class="lede">
             Start with the sample. Switch to live prices or your own CSVs when you're ready.
           </p>
@@ -197,9 +202,15 @@ PAGE_TEMPLATE = """
           </section>
         {% endif %}
 
-        {% if state.chart_data_url %}
+        {% if state.chart_svg %}
           <figure class="chart">
-            <img src="{{ state.chart_data_url }}" alt="{{ state.chart_alt }}">
+            <div class="chart-figure" role="img" aria-label="{{ state.chart_alt }}">
+              {{ state.chart_svg|safe }}
+            </div>
+          </figure>
+        {% elif state.chart_data_url %}
+          <figure class="chart">
+            <img class="chart-figure" src="{{ state.chart_data_url }}" alt="{{ state.chart_alt }}">
           </figure>
         {% endif %}
 
@@ -210,6 +221,11 @@ PAGE_TEMPLATE = """
           </details>
         {% endif %}
       </section>
+
+      <footer class="signature">
+        <span>Monte&nbsp;Carlo · decision engine</span>
+        <a href="https://github.com/pdj555/monte-carlo" rel="noopener">source · github</a>
+      </footer>
     </main>
 
     <script>
@@ -262,6 +278,7 @@ class PageState:
     summary: str
     notes: tuple[str, ...] = ()
     metrics: tuple[Metric, ...] = ()
+    chart_svg: str | None = None
     chart_data_url: str | None = None
     chart_alt: str = ""
     details_text: str = ""
@@ -364,9 +381,81 @@ def _format_pct(value: float, *, signed: bool = False) -> str:
     return f"{value:+.1%}" if signed else f"{value:.1%}"
 
 
-def _encode_figure(fig: plt.Figure) -> str:
+# Editorial palette — must stay aligned with public/styles.css.
+_CHART_PAPER = "#f4efe6"
+_CHART_MUTED = "#8d877c"
+_CHART_HAIRLINE = "#2a2724"
+_CHART_GOLD = "#d4a373"
+_CHART_SAGE = "#8fb59a"
+
+
+def _apply_chart_style(fig: plt.Figure) -> None:
+    fig.patch.set_alpha(0.0)
+    for ax in fig.get_axes():
+        ax.set_facecolor("none")
+        for spine_name, spine in ax.spines.items():
+            if spine_name in ("top", "right"):
+                spine.set_visible(False)
+            else:
+                spine.set_color(_CHART_HAIRLINE)
+                spine.set_linewidth(0.8)
+        ax.tick_params(
+            colors=_CHART_MUTED,
+            labelsize=9,
+            length=4,
+            width=0.6,
+        )
+        for label in ax.get_xticklabels() + ax.get_yticklabels():
+            label.set_color(_CHART_MUTED)
+            label.set_fontfamily("monospace")
+        ax.grid(True, which="major", color=_CHART_HAIRLINE, linewidth=0.5, alpha=0.6)
+        ax.set_axisbelow(True)
+        if ax.get_title():
+            ax.set_title(
+                ax.get_title(),
+                color=_CHART_PAPER,
+                fontsize=12,
+                pad=14,
+                loc="left",
+                fontweight="normal",
+            )
+        if ax.get_xlabel():
+            ax.set_xlabel(ax.get_xlabel(), color=_CHART_MUTED, fontsize=10)
+        if ax.get_ylabel():
+            ax.set_ylabel(ax.get_ylabel(), color=_CHART_MUTED, fontsize=10)
+        for line in ax.get_lines():
+            if line.get_color() in {"C0", "#1f77b4", "tab:blue", "blue"}:
+                line.set_color(_CHART_GOLD)
+            line.set_linewidth(max(line.get_linewidth(), 0.9))
+
+
+def _encode_figure_svg(fig: plt.Figure) -> str:
+    _apply_chart_style(fig)
+    buffer = io.StringIO()
+    fig.savefig(
+        buffer,
+        format="svg",
+        bbox_inches="tight",
+        transparent=True,
+        metadata={"Date": None},
+    )
+    plt.close(fig)
+    raw = buffer.getvalue()
+    # Strip XML/doctype prologue so the SVG inlines cleanly inside the page.
+    marker = raw.find("<svg")
+    return raw[marker:] if marker != -1 else raw
+
+
+def _encode_figure_data_url(fig: plt.Figure) -> str:
+    _apply_chart_style(fig)
     buffer = io.BytesIO()
-    fig.savefig(buffer, format="png", bbox_inches="tight")
+    fig.savefig(
+        buffer,
+        format="png",
+        bbox_inches="tight",
+        transparent=True,
+        dpi=180,
+    )
     plt.close(fig)
     return "data:image/png;base64," + base64.b64encode(buffer.getvalue()).decode("ascii")
 
@@ -399,10 +488,10 @@ def _simulate_chart_payload(result: dict[str, object]) -> tuple[str | None, str]
     fig = plot_paths(
         simulations,
         ticker=ticker,
-        title=f"{ticker} simulated paths",
+        title=f"{ticker} · simulated paths",
         max_paths=50,
     )
-    return _encode_figure(fig), f"Simulated price paths for {ticker}"
+    return _encode_figure_svg(fig), f"Simulated price paths for {ticker}"
 
 
 def _backtest_chart_payload(result: dict[str, object]) -> tuple[str | None, str]:
@@ -410,8 +499,8 @@ def _backtest_chart_payload(result: dict[str, object]) -> tuple[str | None, str]
     if not isinstance(equity_curve, pd.DataFrame) or equity_curve.empty:
         return None, ""
 
-    fig = plot_equity_curve(equity_curve, title="Backtest equity curve")
-    return _encode_figure(fig), "Backtest equity curve"
+    fig = plot_equity_curve(equity_curve, title="Backtest · equity curve")
+    return _encode_figure_svg(fig), "Backtest equity curve"
 
 
 def _build_simulation_state(
@@ -474,7 +563,7 @@ def _build_simulation_state(
             ),
         ]
 
-    chart_data_url, chart_alt = _simulate_chart_payload(result)
+    chart_svg, chart_alt = _simulate_chart_payload(result)
     stance = str(action_plan.get("stance", "Decision ready"))
     title = STANCE_LABELS.get(stance, stance.replace("_", " ").title())
     summary = str(action_plan.get("headline", "A fresh read is ready."))
@@ -494,7 +583,7 @@ def _build_simulation_state(
         summary=summary,
         notes=tuple(notes),
         metrics=tuple(metrics),
-        chart_data_url=chart_data_url,
+        chart_svg=chart_svg,
         chart_alt=chart_alt,
         details_text=details_text,
     )
@@ -547,7 +636,7 @@ def _build_backtest_state(
             _format_pct(float(summary["excess_return_vs_equal_weight"]), signed=True),
         ),
     )
-    chart_data_url, chart_alt = _backtest_chart_payload(result)
+    chart_svg, chart_alt = _backtest_chart_payload(result)
     source_note = describe_price_sources(result.get("price_sources")) or SOURCE_NOTES[
         ui_request.source
     ]
@@ -564,7 +653,7 @@ def _build_backtest_state(
         ),
         notes=tuple(notes),
         metrics=metrics,
-        chart_data_url=chart_data_url,
+        chart_svg=chart_svg,
         chart_alt=chart_alt,
         details_text=details_text,
     )

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,13 +1,21 @@
+/*
+  Monte Carlo — minimal, restrained.
+  Type: Fraunces (display serif), Geist (body sans), Geist Mono (tabular figures).
+*/
+
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,300..600,0..100&family=Geist:wght@300..600&family=Geist+Mono:wght@350..500&display=swap");
+
 :root {
-  --ink: #171716;
-  --muted: #5f5d59;
-  --line: rgba(23, 23, 22, 0.12);
-  --panel: rgba(255, 255, 255, 0.76);
-  --accent: #2b6c58;
-  --accent-soft: #dceee7;
-  --warm-soft: #f2e3dc;
-  --alert-ink: #7a3d23;
-  --alert-bg: #f8eeea;
+  --paper: #ece8df;
+  --paper-soft: #c8c3b8;
+  --muted: #75716a;
+  --muted-2: #54514c;
+  --canvas: #0e0d0c;
+  --hairline: rgba(236, 232, 223, 0.10);
+  --hairline-strong: rgba(236, 232, 223, 0.20);
+  --accent: #d4a373;
+  --error: #d57a55;
+  --easing: cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 
 * {
@@ -19,99 +27,107 @@
 }
 
 html {
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.96)),
-    linear-gradient(
-      135deg,
-      rgba(220, 238, 231, 0.85),
-      rgba(242, 227, 220, 0.8) 58%,
-      rgba(248, 248, 245, 0.96)
-    );
+  background: var(--canvas);
+  color-scheme: dark;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  color: var(--ink);
-  font-family:
-    Inter,
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    sans-serif;
+  color: var(--paper);
+  font-family: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-weight: 400;
+  letter-spacing: -0.005em;
+  background: var(--canvas);
 }
 
 .shell {
-  width: min(1120px, calc(100% - 32px));
+  width: min(960px, calc(100% - 48px));
   margin: 0 auto;
-  padding: 32px 0 48px;
+  padding: 96px 0 96px;
 }
 
+/* ── Masthead ──────────────────────────────────────────────────────── */
+
 .masthead {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 24px;
-  padding-bottom: 24px;
-  border-bottom: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  padding-bottom: 56px;
+  animation: rise 600ms var(--easing) both;
 }
 
 .eyebrow {
-  margin: 0 0 10px;
-  color: var(--accent);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  display: inline-block;
+  margin: 0 0 28px;
+  color: var(--muted);
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
 }
 
 h1 {
   margin: 0;
-  max-width: 10ch;
-  font-size: 42px;
+  max-width: 18ch;
+  font-family: "Fraunces", "Iowan Old Style", Georgia, serif;
+  font-variation-settings: "opsz" 144, "SOFT" 40;
+  font-size: clamp(40px, 5.6vw, 64px);
   line-height: 1.02;
-  font-weight: 700;
+  letter-spacing: -0.022em;
+  font-weight: 360;
+  color: var(--paper);
+}
+
+h1 em {
+  font-style: normal;
 }
 
 .lede {
-  margin: 14px 0 0;
-  max-width: 52ch;
+  margin: 22px 0 0;
+  max-width: 46ch;
   color: var(--muted);
   font-size: 16px;
-  line-height: 1.55;
+  line-height: 1.6;
 }
 
 .masthead-note {
-  margin: 2px 0 0;
-  max-width: 18ch;
-  color: var(--muted);
-  font-size: 14px;
-  line-height: 1.45;
-  text-align: right;
+  margin: 24px 0 0;
+  max-width: 46ch;
+  color: var(--muted-2);
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 12px;
+  line-height: 1.55;
 }
+
+/* ── Controls ──────────────────────────────────────────────────────── */
 
 .controls {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
-  gap: 18px 16px;
+  gap: 24px 20px;
   align-items: end;
-  padding: 24px 0 28px;
-  border-bottom: 1px solid var(--line);
+  padding: 36px 0;
+  border-top: 1px solid var(--hairline-strong);
+  border-bottom: 1px solid var(--hairline-strong);
+  animation: rise 650ms 60ms var(--easing) both;
 }
 
 .group {
   display: grid;
-  gap: 10px;
+  gap: 12px;
 }
 
 .group span,
 .group legend {
   padding: 0;
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 600;
+  color: var(--muted-2);
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
 }
 
 .group fieldset {
@@ -120,31 +136,16 @@ h1 {
   border: 0;
 }
 
-.group-job {
-  grid-column: span 3;
-}
-
-.group-tickers {
-  grid-column: span 4;
-}
-
-.group-source {
-  grid-column: span 3;
-}
-
-.group-actions {
-  grid-column: span 2;
-  justify-items: end;
-}
-
-.group-path {
-  grid-column: 1 / -1;
-}
+.group-job        { grid-column: span 3; }
+.group-tickers    { grid-column: span 4; }
+.group-source     { grid-column: span 3; }
+.group-actions    { grid-column: span 2; justify-items: end; }
+.group-path       { grid-column: 1 / -1; }
 
 .choice-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
 }
 
 .choice {
@@ -162,46 +163,66 @@ h1 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 42px;
+  min-height: 38px;
   padding: 0 14px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.62);
-  color: var(--ink);
-  font-size: 14px;
-  transition: border-color 140ms ease, background-color 140ms ease, color 140ms ease;
+  border: 1px solid var(--hairline-strong);
+  border-radius: 1px;
+  background: transparent;
+  color: var(--paper);
+  font-size: 13.5px;
+  letter-spacing: -0.005em;
+  transition:
+    border-color 160ms var(--easing),
+    background-color 160ms var(--easing),
+    color 160ms var(--easing);
+}
+
+.choice:hover span {
+  border-color: var(--paper-soft);
 }
 
 .choice input:checked + span {
-  border-color: var(--ink);
-  background: var(--ink);
-  color: #fff;
+  border-color: var(--paper);
+  background: var(--paper);
+  color: var(--canvas);
 }
 
 input[type="text"] {
   width: 100%;
-  min-height: 46px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 0 14px;
-  background: rgba(255, 255, 255, 0.72);
-  color: var(--ink);
-  font: inherit;
+  min-height: 42px;
+  border: 0;
+  border-bottom: 1px solid var(--hairline-strong);
+  border-radius: 0;
+  padding: 0 0 4px;
+  background: transparent;
+  color: var(--paper);
+  font:
+    400 14.5px/1.4 "Geist Mono", ui-monospace, monospace;
+  letter-spacing: -0.005em;
+  transition: border-color 160ms var(--easing);
+}
+
+input[type="text"]::placeholder {
+  color: var(--muted-2);
+}
+
+input[type="text"]:hover {
+  border-color: var(--paper-soft);
 }
 
 input[type="text"]:focus-visible,
 button:focus-visible,
 .choice input:focus-visible + span {
-  outline: 2px solid rgba(43, 108, 88, 0.35);
-  outline-offset: 2px;
+  outline: 1px solid var(--accent);
+  outline-offset: 4px;
 }
 
 .source-note {
   grid-column: 1 / -1;
-  margin: -6px 0 0;
+  margin: -8px 0 0;
   color: var(--muted);
-  font-size: 14px;
-  line-height: 1.45;
+  font-size: 13.5px;
+  line-height: 1.55;
 }
 
 .actions {
@@ -211,157 +232,248 @@ button:focus-visible,
 }
 
 button {
-  min-height: 46px;
+  position: relative;
+  min-height: 42px;
   border: 0;
-  border-radius: 8px;
-  padding: 0 18px;
-  background: var(--ink);
-  color: #fff;
-  font: inherit;
-  font-weight: 600;
+  border-radius: 1px;
+  padding: 0 22px;
+  background: var(--paper);
+  color: var(--canvas);
+  font: 500 12px/1 "Geist Mono", ui-monospace, monospace;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
   cursor: pointer;
+  transition: background-color 160ms var(--easing), color 160ms var(--easing);
+}
+
+button:hover {
+  background: var(--accent);
+  color: var(--canvas);
 }
 
 button[disabled] {
   cursor: wait;
-  opacity: 0.82;
+  opacity: 0.55;
 }
+
+/* ── Result ────────────────────────────────────────────────────────── */
 
 .result {
   display: grid;
-  gap: 20px;
-  padding-top: 28px;
+  gap: 40px;
+  padding-top: 56px;
+  animation: rise 700ms 140ms var(--easing) both;
 }
 
 .headline {
   display: grid;
-  gap: 10px;
+  gap: 14px;
+  max-width: 62ch;
+}
+
+.headline .eyebrow {
+  margin: 0;
 }
 
 .headline h2 {
   margin: 0;
-  max-width: 18ch;
-  font-size: 34px;
-  line-height: 1.05;
-  font-weight: 700;
+  max-width: 22ch;
+  font-family: "Fraunces", "Iowan Old Style", Georgia, serif;
+  font-variation-settings: "opsz" 144, "SOFT" 40;
+  font-size: clamp(26px, 3.2vw, 36px);
+  line-height: 1.06;
+  letter-spacing: -0.018em;
+  font-weight: 360;
+  color: var(--paper);
 }
 
 .summary {
   margin: 0;
-  max-width: 58ch;
+  max-width: 56ch;
   color: var(--muted);
-  font-size: 16px;
-  line-height: 1.55;
+  font-size: 15.5px;
+  line-height: 1.6;
 }
 
 .notes {
   display: grid;
-  gap: 10px;
+  gap: 0;
   margin: 0;
   padding: 0;
   list-style: none;
+  border-top: 1px solid var(--hairline);
 }
 
 .notes li {
-  position: relative;
-  padding-left: 16px;
-  color: var(--muted);
-  font-size: 15px;
-  line-height: 1.5;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--hairline);
+  color: var(--paper);
+  font-size: 14.5px;
+  line-height: 1.55;
 }
 
-.notes li::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0.54em;
-  width: 7px;
-  height: 7px;
-  border-radius: 999px;
-  background: var(--accent);
-}
+/* ── Metrics (terminal-style row) ─────────────────────────────────── */
 
 .metrics {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  border-top: 1px solid var(--hairline-strong);
+  border-bottom: 1px solid var(--hairline-strong);
 }
 
 .metric {
-  padding: 16px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--panel);
-  backdrop-filter: blur(8px);
+  padding: 26px 24px 28px;
+  border-right: 1px solid var(--hairline);
+}
+
+.metric:last-child {
+  border-right: 0;
 }
 
 .metric-label {
-  color: var(--muted);
-  font-size: 13px;
-  line-height: 1.35;
+  color: var(--muted-2);
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
 }
 
 .metric-value {
-  margin-top: 8px;
-  font-size: 28px;
-  line-height: 1.05;
-  font-weight: 650;
+  margin-top: 14px;
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-feature-settings: "tnum" on;
+  font-size: clamp(22px, 2.2vw, 28px);
+  line-height: 1;
+  letter-spacing: -0.012em;
+  font-weight: 400;
+  color: var(--paper);
 }
+
+/* ── Chart ─────────────────────────────────────────────────────────── */
 
 .chart {
   margin: 0;
-  overflow: hidden;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.82);
+  padding: 0;
+  background: transparent;
 }
 
-.chart img {
+.chart-figure {
   display: block;
   width: 100%;
   height: auto;
 }
 
-.alert {
-  padding: 14px 16px;
-  border: 1px solid rgba(122, 61, 35, 0.18);
-  border-radius: 8px;
-  background: var(--alert-bg);
-  color: var(--alert-ink);
-  font-size: 15px;
-  line-height: 1.5;
+.chart-figure img,
+.chart-figure svg {
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
+/* ── Alert ─────────────────────────────────────────────────────────── */
+
+.alert {
+  padding: 14px 0;
+  border-top: 1px solid rgba(213, 122, 85, 0.5);
+  border-bottom: 1px solid rgba(213, 122, 85, 0.5);
+  background: transparent;
+  color: var(--error);
+  font-size: 14.5px;
+  line-height: 1.55;
+}
+
+/* ── Terminal output ──────────────────────────────────────────────── */
+
 details {
-  border-top: 1px solid var(--line);
-  padding-top: 14px;
+  border-top: 1px solid var(--hairline);
+  padding-top: 18px;
 }
 
 details summary {
   cursor: pointer;
-  font-weight: 600;
+  color: var(--muted);
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  list-style: none;
+  user-select: none;
+}
+
+details summary::-webkit-details-marker {
+  display: none;
 }
 
 pre {
-  margin: 14px 0 0;
-  padding: 18px;
+  margin: 16px 0 0;
+  padding: 20px 22px;
   overflow: auto;
-  border-radius: 8px;
-  background: #181817;
-  color: #f5f5f0;
-  font-size: 13px;
-  line-height: 1.55;
+  border: 1px solid var(--hairline);
+  background: transparent;
+  color: var(--paper);
+  font: 400 12.5px/1.6 "Geist Mono", ui-monospace, monospace;
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-@media (max-width: 900px) {
-  .masthead {
-    display: grid;
-  }
+/* ── Footer signature ─────────────────────────────────────────────── */
 
-  .masthead-note {
-    text-align: left;
+.signature {
+  margin-top: 80px;
+  padding-top: 24px;
+  border-top: 1px solid var(--hairline);
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  color: var(--muted-2);
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.signature a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 160ms var(--easing);
+}
+
+.signature a:hover {
+  color: var(--paper);
+}
+
+/* ── Motion ────────────────────────────────────────────────────────── */
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* ── Responsive ───────────────────────────────────────────────────── */
+
+@media (max-width: 860px) {
+  .shell {
+    width: min(100% - 32px, 100%);
+    padding: 56px 0 72px;
   }
 
   .controls {
@@ -374,20 +486,28 @@ pre {
   .group-actions {
     grid-column: span 3;
   }
+
+  .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metric:nth-child(odd) {
+    border-right: 1px solid var(--hairline);
+  }
+
+  .metric:nth-child(even) {
+    border-right: 0;
+  }
+
+  .metric:nth-child(-n+2) {
+    border-bottom: 1px solid var(--hairline);
+  }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 560px) {
   .shell {
     width: min(100% - 24px, 100%);
-    padding-top: 24px;
-  }
-
-  h1 {
-    font-size: 32px;
-  }
-
-  .headline h2 {
-    font-size: 28px;
+    padding: 40px 0 56px;
   }
 
   .controls {
@@ -406,7 +526,20 @@ pre {
     justify-items: stretch;
   }
 
-  .actions {
-    justify-content: space-between;
+  .actions button {
+    width: 100%;
+  }
+
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .metric {
+    border-right: 0 !important;
+    border-bottom: 1px solid var(--hairline);
+  }
+
+  .metric:last-child {
+    border-bottom: 0;
   }
 }

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -14,10 +14,11 @@ def test_vercel_config_targets_flask_app_without_legacy_builds() -> None:
 
     assert config["$schema"] == "https://openapi.vercel.sh/vercel.json"
     assert "builds" not in config
-    assert "app.py" in config["functions"]
-    app_config = config["functions"]["app.py"]
-    assert app_config["includeFiles"] == "sample_data/**"
-    assert "tests/**" in app_config["excludeFiles"]
+    assert "api/*.py" in config["functions"]
+    fn_config = config["functions"]["api/*.py"]
+    assert "sample_data/**" in fn_config["includeFiles"]
+    assert "app.py" in fn_config["includeFiles"]
+    assert "tests/**" in fn_config["excludeFiles"]
 
 
 def test_vercel_runtime_files_include_flask_and_python_version() -> None:

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -45,8 +45,8 @@ def test_create_page_state_for_default_demo_returns_chart() -> None:
 
     assert state.error is None
     assert state.request.source == "demo"
-    assert state.chart_data_url is not None
-    assert state.chart_data_url.startswith("data:image/png;base64,")
+    assert state.chart_svg is not None
+    assert state.chart_svg.startswith("<svg")
     assert state.title
     assert state.source_note == "Data source: bundled sample data."
 
@@ -69,7 +69,7 @@ def test_create_page_state_live_first_handles_download_shape(monkeypatch) -> Non
     state = web_app.create_page_state(web_app.UIRequest(source="auto"))
 
     assert state.error is None
-    assert state.chart_data_url is not None
+    assert state.chart_svg is not None
     assert "Live prices weren’t available" not in state.summary
     assert state.source_note == "Data source: live download."
 
@@ -84,7 +84,7 @@ def test_create_page_state_local_sample_data_handles_multiple_tickers() -> None:
     )
 
     assert state.error is None
-    assert state.chart_data_url is not None
+    assert state.chart_svg is not None
     assert state.source_note == "Data source: bundled sample data for AAPL, MSFT."
     assert "Summary for AAPL" in state.details_text
     assert "Summary for MSFT" in state.details_text
@@ -109,11 +109,11 @@ def test_flask_app_renders_default_demo() -> None:
     body = response.get_data(as_text=True)
 
     assert response.status_code == 200
-    assert "Simulate current ideas or backtest history." in body
+    assert "Simulate" in body and "current ideas" in body and "history" in body
     assert "Try live data" in body
     assert "Terminal output" in body
     assert web_app.SOURCE_NOTES["auto"] in body
-    assert "data:image/png;base64," in body
+    assert "<svg" in body
 
 
 def test_flask_app_surfaces_local_path_guidance() -> None:

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,41 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "pip install -r requirements.txt",
   "functions": {
-    "app.py": {
+    "api/*.py": {
       "maxDuration": 60,
-      "includeFiles": "sample_data/**",
-      "excludeFiles": "{tests/**,docs/**,results/**,.pytest_cache/**,__pycache__/**,*.egg-info/**}"
+      "memory": 1024,
+      "includeFiles": "{sample_data/**,app.py,public_cli.py,simulate_cli.py,legacy_cli.py,cli_shared.py,simulation.py,analysis.py,backtest.py,data.py,decision.py,viz.py,ai.py,cli.py,MonteCarlo.py}",
+      "excludeFiles": "{.venv/**,.pytest_cache/**,__pycache__/**,**/__pycache__/**,*.egg-info/**,docs/**,tests/**,output/**,results/**,uv.lock,.agent/**,.github/**,.claude/**}"
     }
-  }
+  },
+  "rewrites": [
+    { "source": "/((?!styles\\.css|robots\\.txt|favicon\\.ico).*)", "destination": "/api/index" }
+  ],
+  "headers": [
+    {
+      "source": "/styles.css",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=31536000, stale-while-revalidate=86400" },
+        { "key": "Content-Type", "value": "text/css; charset=utf-8" }
+      ]
+    },
+    {
+      "source": "/robots.txt",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=86400" }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
+        { "key": "X-Frame-Options", "value": "DENY" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Pare the UI to Fraunces (display) and Geist / Geist Mono (body, tabular figures) on a dark canvas with hairline rules
- Render simulation and backtest charts as inline themed SVG instead of base64 PNG
- Add `api/index.py` WSGI entrypoint, `.vercelignore`, and cache + security headers in `vercel.json` so the browser UI deploys cleanly on Vercel

## Test plan
- [x] `MPLBACKEND=Agg pytest -q` — 124 passed, 1 skipped
- [x] `flake8 .` — clean
- [x] Production deploy returns 200 on `/`, `/healthz`, and `/styles.css` with the new security and cache headers
- [ ] DNS for `mc.pdj.dev` on Cloudflare points at `cname.vercel-dns.com`