### PR TITLE
Ollama Cloud fallback for Claude workflows and --ai-summary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,9 @@ PORT=8000
 MPLBACKEND=Agg
 
 # Optional AI summaries. Leave blank unless you run with --ai-summary.
+# OLLAMA_API_KEY is preferred when set; otherwise OPENAI_API_KEY is used.
+OLLAMA_API_KEY=
+OLLAMA_BASE_URL=https://ollama.com/v1
+OLLAMA_MODEL=gpt-oss:120b
 OPENAI_API_KEY=
 OPENAI_BASE_URL=https://api.openai.com/v1

--- a/.github/actions/configure-ai/action.yml
+++ b/.github/actions/configure-ai/action.yml
@@ -1,0 +1,52 @@
+name: Configure AI credentials
+description: Claude OAuth first, Ollama Cloud fallback, then Anthropic API key.
+
+inputs:
+  claude_code_oauth_token:
+    description: Primary Claude Code OAuth token
+    required: false
+    default: ""
+  ollama_api_key:
+    description: Fallback Ollama Cloud API key (also wires OpenAI-compatible env for app tests)
+    required: false
+    default: ""
+  anthropic_api_key:
+    description: Fallback Anthropic API key when OAuth and Ollama are unavailable
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+        OLLAMA_API_KEY: ${{ inputs.ollama_api_key }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "${CLAUDE_CODE_OAUTH_TOKEN}" ]; then
+          echo "CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}" >> "$GITHUB_ENV"
+          echo "ai_provider=claude-oauth" >> "$GITHUB_ENV"
+        elif [ -n "${OLLAMA_API_KEY}" ]; then
+          {
+            echo "ANTHROPIC_BASE_URL=https://ollama.com"
+            echo "ANTHROPIC_AUTH_TOKEN=${OLLAMA_API_KEY}"
+            echo "ANTHROPIC_API_KEY="
+            echo "ANTHROPIC_DEFAULT_SONNET_MODEL=glm-5:cloud"
+            echo "ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5:cloud"
+            echo "OPENAI_API_KEY=${OLLAMA_API_KEY}"
+            echo "OPENAI_BASE_URL=https://ollama.com/v1"
+            echo "OLLAMA_API_KEY=${OLLAMA_API_KEY}"
+            echo "OLLAMA_BASE_URL=https://ollama.com/v1"
+            echo "OLLAMA_MODEL=gpt-oss:120b"
+            echo "OPENAI_MODEL=gpt-oss:120b"
+            echo "ai_provider=ollama-cloud"
+          } >> "$GITHUB_ENV"
+        elif [ -n "${ANTHROPIC_API_KEY}" ]; then
+          echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" >> "$GITHUB_ENV"
+          echo "ai_provider=anthropic-api" >> "$GITHUB_ENV"
+        else
+          echo "ai_provider=none" >> "$GITHUB_ENV"
+        fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Configure AI credentials
+        uses: ./.github/actions/configure-ai
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
       - name: Resolve PR head SHA
         id: pr
         env:
@@ -43,8 +50,17 @@ jobs:
       - name: Claude profit-focused review
         id: review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_AUTH_TOKEN: ${{ env.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ env.ANTHROPIC_DEFAULT_SONNET_MODEL }}
+          ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ env.ANTHROPIC_DEFAULT_OPUS_MODEL }}
+          OLLAMA_API_KEY: ${{ env.OLLAMA_API_KEY }}
+          OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ env.OPENAI_BASE_URL }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: "/profit-review REPO: ${{ github.repository }} PR: ${{ inputs.pr_number }} SHA: ${{ steps.pr.outputs.sha }}"
           claude_args: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,11 +35,27 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Configure AI credentials
+        uses: ./.github/actions/configure-ai
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ollama_api_key: ${{ secrets.OLLAMA_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_AUTH_TOKEN: ${{ env.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ env.ANTHROPIC_DEFAULT_SONNET_MODEL }}
+          ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ env.ANTHROPIC_DEFAULT_OPUS_MODEL }}
+          OLLAMA_API_KEY: ${{ env.OLLAMA_API_KEY }}
+          OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: ${{ env.OPENAI_BASE_URL }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ env.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: "/oncall-quant EVENT: ${{ github.event_name }} REPO: ${{ github.repository }} REF: ${{ github.event.issue.number || github.event.pull_request.number || github.ref }}"
           claude_args: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,9 +116,11 @@ The codebase is organized into focused modules with clear separation of concerns
 - Module-level `app` object is what Vercel imports — keep it importable without side effects
 
 **AI Summaries (`ai.py`):**
-- `generate_ai_summary()` hits the OpenAI Responses API (default `gpt-5.2`) when the legacy CLI is run with `--ai-summary`
-- Requires `OPENAI_API_KEY`; honors `OPENAI_BASE_URL`, `OPENAI_MODEL`, and `--ai-model`
+- `generate_ai_summary()` hits an OpenAI-compatible Responses API when the legacy CLI is run with `--ai-summary`
+- Prefers `OLLAMA_API_KEY` + `OLLAMA_BASE_URL` + `OLLAMA_MODEL`; falls back to `OPENAI_*`
 - Raises `OpenAIConfigurationError` / `OpenAIRequestError` — callers degrade gracefully rather than failing the run
+
+**GitHub Actions secrets:** `CLAUDE_CODE_OAUTH_TOKEN` (primary), `OLLAMA_API_KEY` (fallback for `@claude` via Ollama Cloud), `ANTHROPIC_API_KEY` (last resort). Workflows use `.github/actions/configure-ai`.
 
 **Vercel Deployment (`vercel.json`, `api/index.py`, `public/`):**
 - All routes rewrite to `api/index.py` except `/styles.css` and `/robots.txt`, which are served from `public/` with long s-maxage caching

--- a/ai.py
+++ b/ai.py
@@ -1,7 +1,7 @@
-"""OpenAI-powered narrative summaries for simulation output.
+"""OpenAI-compatible narrative summaries for simulation output.
 
-This module is optional: it is only used when the CLI is invoked with
-``--ai-summary`` and a valid ``OPENAI_API_KEY`` is available.
+Optional: used when the CLI is invoked with ``--ai-summary`` and
+``OLLAMA_API_KEY`` or ``OPENAI_API_KEY`` is available.
 """
 
 from __future__ import annotations
@@ -16,6 +16,8 @@ import pandas as pd
 
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_OPENAI_MODEL = "gpt-5.2"
+DEFAULT_OLLAMA_BASE_URL = "https://ollama.com/v1"
+DEFAULT_OLLAMA_MODEL = "gpt-oss:120b"
 
 
 class OpenAIConfigurationError(RuntimeError):
@@ -26,13 +28,31 @@ class OpenAIRequestError(RuntimeError):
     """Raised when an OpenAI API request fails."""
 
 
-def _get_openai_api_key() -> str:
-    api_key = os.getenv("OPENAI_API_KEY")
+def _resolve_openai_credentials() -> tuple[str, str, str]:
+    ollama_key = (os.getenv("OLLAMA_API_KEY") or "").strip()
+    openai_key = (os.getenv("OPENAI_API_KEY") or "").strip()
+    api_key = ollama_key or openai_key
     if not api_key:
         raise OpenAIConfigurationError(
-            "OPENAI_API_KEY is required when --ai-summary is enabled."
+            "OLLAMA_API_KEY or OPENAI_API_KEY is required when --ai-summary is enabled."
         )
-    return api_key
+
+    if ollama_key:
+        base_url = (
+            os.getenv("OLLAMA_BASE_URL")
+            or os.getenv("OPENAI_BASE_URL")
+            or DEFAULT_OLLAMA_BASE_URL
+        )
+        model = (
+            os.getenv("OLLAMA_MODEL")
+            or os.getenv("OPENAI_MODEL")
+            or DEFAULT_OLLAMA_MODEL
+        )
+    else:
+        base_url = os.getenv("OPENAI_BASE_URL") or DEFAULT_OPENAI_BASE_URL
+        model = os.getenv("OPENAI_MODEL") or DEFAULT_OPENAI_MODEL
+
+    return api_key, base_url.rstrip("/"), model
 
 
 def _post_json(
@@ -138,11 +158,9 @@ def generate_ai_summary(
 ) -> str:
     """Generate a concise narrative summary for a single ticker simulation."""
 
-    api_key = _get_openai_api_key()
-    base_url = (
-        base_url or os.getenv("OPENAI_BASE_URL") or DEFAULT_OPENAI_BASE_URL
-    ).rstrip("/")
-    model = model or os.getenv("OPENAI_MODEL") or DEFAULT_OPENAI_MODEL
+    api_key, resolved_base_url, resolved_model = _resolve_openai_credentials()
+    base_url = (base_url or resolved_base_url).rstrip("/")
+    model = model or resolved_model
 
     instructions = (
         "You are a quantitative finance assistant. Summarize Monte Carlo "

--- a/scripts/sync-ollama-secret.sh
+++ b/scripts/sync-ollama-secret.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${OLLAMA_API_KEY:-}" ]; then
+  echo "Set OLLAMA_API_KEY in your shell, then re-run." >&2
+  echo "  export OLLAMA_API_KEY='...'" >&2
+  exit 1
+fi
+
+REPOS=(
+  monte-carlo
+  stock-sentiment-analysis
+  ethereum-blocks
+  energy-market-visualization
+  raft-consensus
+)
+
+for repo in "${REPOS[@]}"; do
+  echo "Setting OLLAMA_API_KEY on pdj555/${repo}..."
+  gh secret set OLLAMA_API_KEY -R "pdj555/${repo}" --body "$OLLAMA_API_KEY"
+done
+
+echo "Done."


### PR DESCRIPTION
## Summary
- Adds `.github/actions/configure-ai` — OAuth → `OLLAMA_API_KEY` → `ANTHROPIC_API_KEY`
- Wires all Claude workflows to use configured env instead of raw secrets
- `ai.py` and `.env.example` prefer `OLLAMA_*` over `OPENAI_*` for `--ai-summary`
- Includes `scripts/sync-ollama-secret.sh` to push the secret to all portfolio repos

## Test plan
- [ ] Merge after CI green
- [ ] Confirm `@claude` workflow runs with Ollama when OAuth unset (`ai_provider=ollama-cloud` in logs)