### PR TITLE
Add reproducible scenario-set evaluations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@
 - `ui_state.py`: presentation state builder shared by the browser bridge.
 - `ui_bridge.py`: JSON bridge used by the Next.js API route.
 - `web_entrypoint.py`: local `monte-carlo-ui` launcher for the Next.js workbench.
-- `public_cli.py`: public CLI implementation for `monte-carlo simulate|backtest`.
+- `public_cli.py`: public CLI implementation for `monte-carlo simulate|backtest|evaluate`.
+- `evaluation.py`: versioned scenario-evaluation contracts and scorecard aggregation.
+- `evaluation_sets/`: versioned, bounded scenario manifests for offline evaluation.
 - `simulate_cli.py`: shared simulation workflow used by public and legacy entrypoints.
 - `cli_shared.py`: shared parser and rendering helpers for CLI surfaces.
 - `backtest.py`: walk-forward engine plus deprecated backtest wrapper.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ monte-carlo evaluate evaluation_sets/sample-stability.json --output results/eval
 ```
 
 Use `evaluate` to gate a decision across seeds and models before capital is risked.
+The reference manifest and `sample_data/` are source-checkout assets and are not included
+in the installed wheel. Wheel users must supply their own evaluation-set JSON and local
+data paths.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ monte-carlo backtest AAPL MSFT --lookback 60 --hold 20 --rebalance 20
 
 # Offline fixtures
 monte-carlo simulate AAPL --source offline --data-path sample_data
+
+# Decision-stability gate before capital is risked
+monte-carlo evaluate evaluation_sets/sample-stability.json --output results/evaluation
 ```
+
+Use `evaluate` to gate a decision across seeds and models before capital is risked.
 
 ## Architecture
 

--- a/docs/improvements.md
+++ b/docs/improvements.md
@@ -10,27 +10,26 @@ interface.
 - Install the browser surface with `npm install`
 - Run simulations with `monte-carlo simulate [TICKER ...]`
 - Run walk-forward validation with `monte-carlo backtest [TICKER ...]`
+- Run reproducible decision-stability checks with `monte-carlo evaluate SET_FILE`
 - Run the browser workbench with `npm run dev`
 - Keep `python cli.py`, `python backtest.py`, and `python MonteCarlo.py` only
   as deprecated compatibility wrappers during migration
 
+## Shipped Foundation
+
+Scenario-set evaluations now run a bounded, versioned matrix across universes,
+models, seeds, and sources. The public command produces an auditable scorecard.
+
 ## Current Opportunities
 
-### 1. Add scenario-set evaluations
-
-Persist named evaluation sets that exercise multiple universes, seeds, models,
-and source modes. The highest-value version is a single command that produces a
-small scorecard for ranking stability, data-source reliability, and downside
-guardrail behavior.
-
-### 2. Make the bridge contract typed end to end
+### 1. Make the bridge contract typed end to end
 
 The Next.js UI currently calls a compact JSON bridge over `ui_bridge.py`. The
 next refinement is to generate a shared schema for `WorkbenchPayload`, validate
 the Python response at the route boundary, and keep the UI resilient when a
 field is missing.
 
-### 3. Extend provenance checks when new artifacts appear
+### 2. Extend provenance checks when new artifacts appear
 
 Simulation reports and backtest folders persist source provenance. Future
 export formats should keep the same audit trail and land with regression

--- a/docs/output-guide.md
+++ b/docs/output-guide.md
@@ -56,6 +56,21 @@ Open these first:
 - `price_sources.json` records where the history came from so live, offline,
   and fallback runs stay auditable after the terminal closes.
 
+## Evaluate
+
+Example folder:
+
+```text
+results/evaluation/
+  scorecard.md
+  runs.csv
+  report.json
+```
+
+Open `scorecard.md` first. Use `runs.csv` to isolate unstable or failed matrix
+cells. `report.json` preserves the manifest hash, normalized matrix, outcomes,
+and source reliability for later audit.
+
 ## Good Handoff
 
 - Send `action_plan.md` or `backtest_summary.csv` when someone only needs the

--- a/docs/superpowers/plans/2026-07-25-scenario-evaluation.md
+++ b/docs/superpowers/plans/2026-07-25-scenario-evaluation.md
@@ -1,0 +1,469 @@
+# Scenario-Set Evaluation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reproducible `monte-carlo evaluate` workflow that measures ranking stability, data-source reliability, and downside guardrail behavior across a bounded matrix of universes, models, seeds, and source modes.
+
+**Architecture:** A new dependency-free `evaluation.py` module owns the versioned JSON contract, deterministic matrix expansion, run normalization, scorecard aggregation, and artifact persistence. `public_cli.py` remains the thin operator surface: it adapts each evaluation run to the existing simulation workflow, renders the scorecard, and returns CI-useful exit codes. A small bundled offline evaluation set proves the complete path without network access.
+
+**Tech Stack:** Python 3.9+, standard-library dataclasses/JSON/CSV/statistics, existing pandas-backed simulation engine, argparse, pytest.
+
+## Global Constraints
+
+- Preserve the existing `monte-carlo simulate` and `monte-carlo backtest` contracts.
+- Add exactly one public command: `monte-carlo evaluate SET_FILE [--output DIR]`.
+- Evaluation files use `schema_version: 1` and expand to at most `100` runs.
+- Supported models are exactly `historical` and `gbm`; supported source modes are exactly `auto`, `offline`, and `online`.
+- Resolve relative `data_path` values against the evaluation file's directory, never the caller's current directory.
+- Execute the existing public simulation engine through an injected runner; do not duplicate simulation or ranking logic.
+- Preserve deterministic run ordering: universe, then model, then seed, then source, all in manifest order.
+- Persist exactly `scorecard.md`, `runs.csv`, and `report.json` when `--output` is supplied.
+- Return exit code `0` when every expanded run completes, `1` when any run fails, and `2` for invalid input or an unexpected command failure.
+- Add no runtime dependency and make no network call in tests.
+- Keep user-facing names and errors concise, specific, and actionable.
+
+---
+
+## File Structure
+
+- `evaluation.py`: versioned evaluation contract, validation, matrix expansion, run normalization, aggregation, formatting, and persistence.
+- `tests/test_evaluation.py`: focused contract, validation, aggregation, failure-isolation, and artifact tests using injected deterministic runners.
+- `public_cli.py`: parser and adapter for the new public command only; the simulation engine stays unchanged.
+- `evaluation_sets/sample-stability.json`: fast, deterministic, offline reference set using bundled AAPL/MSFT history.
+- `tests/test_cli.py`: parser and real end-to-end command coverage.
+- `tests/test_installation.py`: installed entrypoint discovery for `evaluate --help`.
+- `tests/test_docs.py`: operator-document and reference-set coverage.
+- `pyproject.toml`: package the new top-level module.
+- `README.md`, `AGENTS.md`, `docs/output-guide.md`, `docs/improvements.md`: concise operator and maintainer guidance.
+
+### Task 1: Evaluation Core
+
+**Files:**
+- Create: `evaluation.py`
+- Create: `tests/test_evaluation.py`
+- Modify: `pyproject.toml`
+
+**Interfaces:**
+- Produces: `EvaluationConfigError(ValueError)`.
+- Produces: immutable `EvaluationUniverse`, `EvaluationSource`, `EvaluationSet`, and `EvaluationRun` dataclasses.
+- Produces: immutable `EvaluationRunOutcome`, `EvaluationScorecard`, and `EvaluationReport` dataclasses, each with a JSON-safe `to_dict()` where persisted.
+- Produces: `load_evaluation_set(path: str | Path) -> EvaluationSet`.
+- Produces: `expand_evaluation_runs(evaluation_set: EvaluationSet) -> tuple[EvaluationRun, ...]`.
+- Produces: `evaluate_scenario_set(evaluation_set: EvaluationSet, runner: Callable[[EvaluationRun], Mapping[str, object]]) -> EvaluationReport`.
+- Produces: `format_evaluation_scorecard(report: EvaluationReport) -> str`.
+- Produces: `save_evaluation_report(report: EvaluationReport, output_dir: str | Path) -> tuple[Path, Path, Path]` returning paths in scorecard/runs/report order.
+- Consumes: the existing simulation result shape: `result["report"]["rankings"]`, `result["report"]["action_plan"]`, `result["report"]["results"]`, `result["report"]["errors"]`, and `result["price_sources"]`.
+
+- [ ] **Step 1: Write contract and matrix-expansion tests**
+
+Create `tests/test_evaluation.py` with helpers that write JSON manifests under `tmp_path`. Cover the exact contract below:
+
+```python
+def test_load_evaluation_set_resolves_paths_and_expands_in_manifest_order(tmp_path):
+    set_path = write_set(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "name": "core-stability",
+            "days": 20,
+            "scenarios": 250,
+            "universes": [
+                {"name": "tech", "tickers": ["aapl", "MSFT"]},
+                {"name": "single", "tickers": ["JPM"]},
+            ],
+            "models": ["historical", "gbm"],
+            "seeds": [7, 42],
+            "sources": [
+                {"name": "bundled", "mode": "offline", "data_path": "../prices"},
+                {"name": "live", "mode": "online"},
+            ],
+        },
+    )
+
+    evaluation_set = load_evaluation_set(set_path)
+    runs = expand_evaluation_runs(evaluation_set)
+
+    assert len(runs) == 16
+    assert evaluation_set.universes[0].tickers == ("AAPL", "MSFT")
+    assert evaluation_set.sources[0].data_path == (tmp_path / "../prices").resolve()
+    assert [
+        (run.universe_name, run.model, run.seed, run.source_name)
+        for run in runs[:4]
+    ] == [
+        ("tech", "historical", 7, "bundled"),
+        ("tech", "historical", 7, "live"),
+        ("tech", "historical", 42, "bundled"),
+        ("tech", "historical", 42, "live"),
+    ]
+```
+
+Add parametrized invalid-manifest cases for: unknown top-level keys, missing/unsupported `schema_version`, duplicate names, empty tickers/models/seeds/sources, invalid ticker tokens, negative or boolean seeds, unsupported models/source modes, offline sources without `data_path`, non-positive days/scenarios, and a Cartesian product above `100` runs. Assert each `EvaluationConfigError` names the offending field and tells the operator how to fix it.
+
+- [ ] **Step 2: Run the contract tests and verify RED**
+
+Run: `MPLBACKEND=Agg pytest -q tests/test_evaluation.py`
+
+Expected: FAIL during collection because `evaluation` does not exist.
+
+- [ ] **Step 3: Implement the versioned contract and deterministic expansion**
+
+In `evaluation.py`, define these constants and dataclass fields exactly:
+
+```python
+EVALUATION_SCHEMA_VERSION = 1
+MAX_EVALUATION_RUNS = 100
+SUPPORTED_MODELS = ("historical", "gbm")
+SUPPORTED_SOURCE_MODES = ("auto", "offline", "online")
+
+@dataclass(frozen=True)
+class EvaluationUniverse:
+    name: str
+    tickers: tuple[str, ...]
+
+@dataclass(frozen=True)
+class EvaluationSource:
+    name: str
+    mode: str
+    data_path: Path | None = None
+
+@dataclass(frozen=True)
+class EvaluationSet:
+    name: str
+    days: int
+    scenarios: int
+    universes: tuple[EvaluationUniverse, ...]
+    models: tuple[str, ...]
+    seeds: tuple[int, ...]
+    sources: tuple[EvaluationSource, ...]
+    manifest_path: Path
+    manifest_sha256: str
+
+@dataclass(frozen=True)
+class EvaluationRun:
+    run_id: str
+    universe_name: str
+    tickers: tuple[str, ...]
+    model: str
+    seed: int
+    source_name: str
+    source_mode: str
+    data_path: Path | None
+    days: int
+    scenarios: int
+```
+
+Use a strict allowed-key check at every object level. Reject booleans where integers are required. Normalize tickers to uppercase, de-duplicate only by rejecting duplicates, and accept ticker tokens only when they match `^[A-Z0-9][A-Z0-9.^=-]{0,14}$`. Hash the exact manifest bytes with SHA-256. Construct `run_id` as `<universe>/<model>/seed-<seed>/<source>` and enforce the `100`-run cap before returning the set.
+
+- [ ] **Step 4: Run the contract tests and verify GREEN**
+
+Run: `MPLBACKEND=Agg pytest -q tests/test_evaluation.py`
+
+Expected: all contract and expansion tests pass with pristine output.
+
+- [ ] **Step 5: Write failing aggregation, isolation, and artifact tests**
+
+Add deterministic fake runners that return the same mapping shape as `simulate_cli.run`. The completed result helper must include ordered rankings, action-plan stance/top pick, completed ticker results, source provenance, and optional guardrail reasons. Cover:
+
+```python
+def test_evaluate_scenario_set_reports_stability_reliability_and_downside(tmp_path):
+    evaluation_set = load_evaluation_set(write_two_seed_set(tmp_path))
+
+    def runner(run):
+        if run.seed == 7:
+            return simulation_result(
+                rankings=[
+                    ("AAPL", 12.0, "BUY", "", 0.08),
+                    ("MSFT", 8.0, "AVOID", "expected_return<0.0%", 0.14),
+                ],
+                top_pick="AAPL",
+                stance="SELECTIVE",
+            )
+        return simulation_result(
+            rankings=[
+                ("MSFT", 11.0, "BUY", "", 0.10),
+                ("AAPL", 9.0, "BUY", "", 0.20),
+            ],
+            top_pick="MSFT",
+            stance="RISK_ON",
+        )
+
+    report = evaluate_scenario_set(evaluation_set, runner)
+
+    assert report.scorecard.run_success_rate == pytest.approx(1.0)
+    assert report.scorecard.ticker_success_rate == pytest.approx(1.0)
+    assert report.scorecard.mean_rank_correlation == pytest.approx(-1.0)
+    assert report.scorecard.top_pick_consistency == pytest.approx(0.5)
+    assert report.scorecard.guardrail_rejection_rate == pytest.approx(0.25)
+    assert report.scorecard.no_trade_rate == pytest.approx(0.0)
+    assert report.scorecard.worst_var_95_pct == pytest.approx(0.20)
+```
+
+Also prove: one runner exception becomes a failed outcome without aborting later runs; empty rankings become a failed outcome with the simulation errors joined into an actionable message; source reliability is grouped by the manifest's source name; rank correlation is `None` when fewer than two comparable completed runs exist; `format_evaluation_scorecard` renders `n/a` for unavailable metrics; and artifact persistence creates exactly the three required files with parseable JSON/CSV and the same displayed scorecard.
+
+- [ ] **Step 6: Run the new aggregation tests and verify RED**
+
+Run: `MPLBACKEND=Agg pytest -q tests/test_evaluation.py`
+
+Expected: FAIL because report aggregation and persistence interfaces are not implemented.
+
+- [ ] **Step 7: Implement run normalization, scorecard aggregation, and persistence**
+
+Implement immutable outcomes and reports with these fields:
+
+```python
+@dataclass(frozen=True)
+class EvaluationRunOutcome:
+    run_id: str
+    universe_name: str
+    model: str
+    seed: int
+    source_name: str
+    source_mode: str
+    requested_tickers: int
+    completed_tickers: int
+    status: str
+    error: str | None
+    stance: str | None
+    top_pick: str | None
+    rank_order: tuple[str, ...]
+    guardrail_rejections: int
+    worst_var_95_pct: float | None
+
+@dataclass(frozen=True)
+class EvaluationScorecard:
+    total_runs: int
+    completed_runs: int
+    failed_runs: int
+    run_success_rate: float
+    ticker_success_rate: float
+    mean_rank_correlation: float | None
+    top_pick_consistency: float | None
+    guardrail_rejection_rate: float
+    no_trade_rate: float
+    worst_var_95_pct: float | None
+    source_reliability: dict[str, dict[str, int | float]]
+
+@dataclass(frozen=True)
+class EvaluationReport:
+    schema_version: int
+    evaluation_set: EvaluationSet
+    generated_at: str
+    outcomes: tuple[EvaluationRunOutcome, ...]
+    scorecard: EvaluationScorecard
+```
+
+Treat a run as completed only when rankings are a non-empty mapping. Count completed tickers from `report.results`, guardrail rejections from rows whose recommendation is `AVOID` and whose `guardrail_reasons` is non-empty, and the worst downside from `value_at_risk_95_pct`. Compute mean rank correlation only across outcome pairs from the same universe with at least two common ranked tickers, using a local Pearson calculation over their rank positions. Compute top-pick consistency per universe and average those universe ratios so large matrices do not drown out small universes. Catch `Exception` around each injected runner call, preserve the exception message in that outcome, and continue the deterministic matrix.
+
+Format the scorecard as:
+
+```text
+Evaluation set: sample-stability
+Runs: 6/6 complete (100.0%)
+Ticker coverage: 100.0%
+Mean rank correlation: 92.5%
+Top-pick consistency: 83.3%
+Guardrail rejections: 16.7%
+No-trade runs: 0.0%
+Worst observed 95% downside: 14.2%
+Source reliability:
+  bundled: 6/6 complete (100.0%)
+```
+
+`report.json` must contain the manifest name/path/hash, normalized matrix, complete outcomes, and scorecard. `runs.csv` must have one row per outcome in run order and join `rank_order` with ` > `. `scorecard.md` must be the formatted scorecard plus one trailing newline. Create the output directory with `parents=True, exist_ok=True`.
+
+- [ ] **Step 8: Package the module and verify the task**
+
+Add `"evaluation"` to `tool.setuptools.py-modules` in `pyproject.toml`.
+
+Run:
+
+```bash
+MPLBACKEND=Agg pytest -q tests/test_evaluation.py
+flake8 evaluation.py tests/test_evaluation.py
+MPLBACKEND=Agg pytest -q
+```
+
+Expected: all commands pass; the full suite remains at least `136 passed` with no new failures.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add evaluation.py tests/test_evaluation.py pyproject.toml
+git commit -m "Add scenario evaluation core"
+```
+
+### Task 2: Public CLI and Operator Workflow
+
+**Files:**
+- Create: `evaluation_sets/sample-stability.json`
+- Modify: `public_cli.py`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_installation.py`
+- Modify: `tests/test_docs.py`
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+- Modify: `docs/output-guide.md`
+- Modify: `docs/improvements.md`
+
+**Interfaces:**
+- Consumes: all Task 1 interfaces exactly as declared above.
+- Produces: public `monte-carlo evaluate SET_FILE [--output DIR]` command.
+- Produces: `execute_public_evaluate(args: argparse.Namespace) -> EvaluationReport` for programmatic callers.
+- Produces: `run_public_evaluate(args: argparse.Namespace) -> EvaluationReport` for formatted CLI execution.
+- Produces: `evaluation_sets/sample-stability.json`, a six-run offline set: one universe × two models × three seeds × one source.
+
+- [ ] **Step 1: Write failing parser and end-to-end CLI tests**
+
+In `tests/test_cli.py`, add parser coverage and a real offline command test:
+
+```python
+def test_public_parser_accepts_evaluation_set_and_output():
+    args = parse_public_args(
+        ["evaluate", "evaluation_sets/sample-stability.json", "--output", "results/eval"]
+    )
+
+    assert args.command == "evaluate"
+    assert args.set_file == "evaluation_sets/sample-stability.json"
+    assert args.output == "results/eval"
+
+
+def test_public_evaluate_runs_reference_set_and_writes_auditable_outputs(tmp_path, capsys):
+    output = tmp_path / "evaluation"
+
+    exit_code = main(
+        [
+            "evaluate",
+            "evaluation_sets/sample-stability.json",
+            "--output",
+            str(output),
+        ]
+    )
+
+    rendered = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Evaluation set: sample-stability" in rendered
+    assert "Runs: 6/6 complete (100.0%)" in rendered
+    assert {path.name for path in output.iterdir()} == {
+        "scorecard.md",
+        "runs.csv",
+        "report.json",
+    }
+```
+
+Add a focused monkeypatched test proving `main(["evaluate", ...])` returns `1` when the report scorecard has failed runs, and a malformed manifest test proving the error is actionable and returns `2`.
+
+- [ ] **Step 2: Run the CLI tests and verify RED**
+
+Run: `MPLBACKEND=Agg pytest -q tests/test_cli.py -k evaluate`
+
+Expected: FAIL because `evaluate` is not a recognized command.
+
+- [ ] **Step 3: Add the thin CLI adapter**
+
+Import Task 1 interfaces into `public_cli.py`. Add the parser:
+
+```python
+evaluate_parser = subparsers.add_parser(
+    "evaluate",
+    help="Test decision stability across a reproducible scenario set.",
+    formatter_class=IntentionalDefaultsHelpFormatter,
+)
+evaluate_parser.add_argument(
+    "set_file",
+    help="Versioned JSON evaluation-set file.",
+)
+evaluate_parser.add_argument(
+    "--output",
+    default=None,
+    help="Directory for scorecard.md, runs.csv, and report.json.",
+)
+```
+
+Adapt each `EvaluationRun` to the existing `execute_public_simulate` function with an `argparse.Namespace` containing: `tickers`, `days`, `scenarios`, `model`, `seed`, `source`, `data_path`, `output=None`, `show=False`, and `details=False`. Do not call private simulation functions or render per-run output. `run_public_evaluate` prints the formatted scorecard once and saves artifacts only when `args.output` is present. In `main`, return `1` when `report.scorecard.failed_runs > 0`; let the existing command-level exception path return `2` for invalid manifests or unexpected failures.
+
+- [ ] **Step 4: Add the deterministic reference set**
+
+Create `evaluation_sets/sample-stability.json` with this exact content:
+
+```json
+{
+  "schema_version": 1,
+  "name": "sample-stability",
+  "days": 5,
+  "scenarios": 100,
+  "universes": [
+    {
+      "name": "large-cap-tech",
+      "tickers": ["AAPL", "MSFT"]
+    }
+  ],
+  "models": ["historical", "gbm"],
+  "seeds": [7, 42, 99],
+  "sources": [
+    {
+      "name": "bundled",
+      "mode": "offline",
+      "data_path": "../sample_data"
+    }
+  ]
+}
+```
+
+- [ ] **Step 5: Run focused CLI tests and verify GREEN**
+
+Run: `MPLBACKEND=Agg pytest -q tests/test_cli.py -k evaluate`
+
+Expected: all evaluate tests pass with pristine output.
+
+- [ ] **Step 6: Add installed-entrypoint and documentation tests**
+
+Update `tests/test_installation.py` so the help loop includes `["evaluate", "--help"]` and the no-command hint includes `evaluate`. Update `tests/test_docs.py` to require:
+
+- `monte-carlo evaluate evaluation_sets/sample-stability.json --output results/evaluation` in `README.md`.
+- `scorecard.md`, `runs.csv`, and the evaluation `report.json` explanation in `docs/output-guide.md`.
+- `evaluation.py` and `evaluation_sets/` in `AGENTS.md`.
+- A real `load_evaluation_set("evaluation_sets/sample-stability.json")` assertion that expands to six runs and resolves its source path to the repository's `sample_data` directory.
+
+- [ ] **Step 7: Run the documentation tests and verify RED**
+
+Run: `MPLBACKEND=Agg pytest -q tests/test_installation.py tests/test_docs.py`
+
+Expected: FAIL until the operator documentation and help text describe the new workflow.
+
+- [ ] **Step 8: Document the minimum operator path and close the shipped backlog item**
+
+Add one evaluate example to the README CLI block and one sentence explaining that it gates a decision across seeds/models before capital is risked. Add an `Evaluate` section to `docs/output-guide.md` with this output tree:
+
+```text
+results/evaluation/
+  scorecard.md
+  runs.csv
+  report.json
+```
+
+Explain that `scorecard.md` is the first read, `runs.csv` isolates unstable or failed matrix cells, and `report.json` preserves the manifest hash, normalized matrix, outcomes, and source reliability. Update `docs/improvements.md` by replacing “Add scenario-set evaluations” with a short `Shipped foundation` entry and leave the typed bridge contract and provenance-extension opportunities as the only current opportunities. Add the two new paths to the `AGENTS.md` structure list. Keep all copy factual and compact.
+
+- [ ] **Step 9: Verify all Task 2 surfaces**
+
+Run:
+
+```bash
+MPLBACKEND=Agg pytest -q tests/test_cli.py tests/test_installation.py tests/test_docs.py tests/test_evaluation.py
+flake8 public_cli.py evaluation.py tests/test_cli.py tests/test_evaluation.py tests/test_docs.py tests/test_installation.py
+MPLBACKEND=Agg python -m public_cli evaluate evaluation_sets/sample-stability.json --output /tmp/monte-carlo-evaluation-smoke
+```
+
+Expected: tests and lint pass; the smoke command prints `Runs: 6/6 complete (100.0%)` and writes exactly the three documented artifacts.
+
+- [ ] **Step 10: Commit Task 2**
+
+```bash
+git add public_cli.py evaluation_sets/sample-stability.json tests/test_cli.py tests/test_installation.py tests/test_docs.py README.md AGENTS.md docs/output-guide.md docs/improvements.md
+git commit -m "Expose reproducible scenario evaluations"
+```
+
+## Plan Self-Review
+
+- Spec coverage: Task 1 owns the versioned contract, bounded deterministic expansion, aggregation, failure isolation, and persistence. Task 2 owns the public command, reference set, CI-useful exits, packaging integration, and operator guidance.
+- Placeholder scan: every implementation step names exact interfaces, values, file paths, commands, and expected behavior; no deferred implementation markers remain.
+- Type consistency: Task 2 consumes the exact `EvaluationRun` and `EvaluationReport` interfaces produced by Task 1. The manifest field names, output filenames, run limits, supported values, and exit codes match across both tasks.

--- a/evaluation.py
+++ b/evaluation.py
@@ -11,6 +11,7 @@ from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from types import MappingProxyType
 from typing import Callable, Mapping
 
 
@@ -20,6 +21,7 @@ SUPPORTED_MODELS = ("historical", "gbm")
 SUPPORTED_SOURCE_MODES = ("auto", "offline", "online")
 
 _TICKER_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9.^=-]{0,14}$")
+_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 
 
 class EvaluationConfigError(ValueError):
@@ -167,7 +169,10 @@ class EvaluationScorecard:
             "guardrail_rejection_rate": self.guardrail_rejection_rate,
             "no_trade_rate": self.no_trade_rate,
             "worst_var_95_pct": self.worst_var_95_pct,
-            "source_reliability": self.source_reliability,
+            "source_reliability": {
+                name: dict(reliability)
+                for name, reliability in self.source_reliability.items()
+            },
         }
 
 
@@ -219,6 +224,17 @@ def _positive_int(value: object, field: str) -> int:
     return value
 
 
+def _safe_name(value: object, field: str) -> str:
+    name = _nonempty_string(value, field)
+    if not _NAME_PATTERN.fullmatch(name):
+        _config_error(
+            field,
+            "must be a safe token",
+            "Use 1-64 letters, digits, periods, underscores, or hyphens with no slashes",
+        )
+    return name
+
+
 def _required(mapping: Mapping[str, object], key: str, field: str) -> object:
     if key not in mapping:
         _config_error(field, "is required", "Provide this field")
@@ -242,7 +258,7 @@ def load_evaluation_set(path: str | Path) -> EvaluationSet:
         ) from exc
     try:
         document = json.loads(manifest_bytes)
-    except (TypeError, json.JSONDecodeError) as exc:
+    except (TypeError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise EvaluationConfigError(
             "manifest: invalid JSON. Provide a valid JSON evaluation manifest"
         ) from exc
@@ -286,7 +302,7 @@ def load_evaluation_set(path: str | Path) -> EvaluationSet:
     for index, raw_universe in enumerate(raw_universes):
         field = f"universes[{index}]"
         universe = _strict_keys(raw_universe, {"name", "tickers"}, field)
-        universe_name = _nonempty_string(
+        universe_name = _safe_name(
             _required(universe, "name", f"{field}.name"), f"{field}.name"
         )
         raw_tickers = _required(universe, "tickers", f"{field}.tickers")
@@ -345,7 +361,9 @@ def load_evaluation_set(path: str | Path) -> EvaluationSet:
     for index, raw_source in enumerate(raw_sources):
         field = f"sources[{index}]"
         source = _strict_keys(raw_source, {"name", "mode", "data_path"}, field)
-        source_name = _nonempty_string(_required(source, "name", f"{field}.name"), f"{field}.name")
+        source_name = _safe_name(
+            _required(source, "name", f"{field}.name"), f"{field}.name"
+        )
         source_mode = _nonempty_string(_required(source, "mode", f"{field}.mode"), f"{field}.mode")
         if source_mode not in SUPPORTED_SOURCE_MODES:
             _config_error(
@@ -519,7 +537,8 @@ def _normalise_outcome(run: EvaluationRun, result: Mapping[str, object]) -> Eval
 
 
 def _rank_correlation(left: tuple[str, ...], right: tuple[str, ...]) -> float | None:
-    common = [ticker for ticker in left if ticker in set(right)]
+    right_set = set(right)
+    common = [ticker for ticker in left if ticker in right_set]
     if len(common) < 2:
         return None
     left_positions = {ticker: index + 1 for index, ticker in enumerate(left)}
@@ -593,12 +612,17 @@ def _scorecard(outcomes: tuple[EvaluationRunOutcome, ...]) -> EvaluationScorecar
             guardrails / completed_tickers if completed_tickers else 0.0
         ),
         no_trade_rate=(
-            sum(outcome.stance == "NO_TRADE" for outcome in completed) / completed_runs
+            sum(outcome.top_pick is None for outcome in completed) / completed_runs
             if completed_runs
             else 0.0
         ),
         worst_var_95_pct=max(downside_values) if downside_values else None,
-        source_reliability=source_reliability,
+        source_reliability=MappingProxyType(
+            {
+                name: MappingProxyType(dict(reliability))
+                for name, reliability in source_reliability.items()
+            }
+        ),
     )
 
 

--- a/evaluation.py
+++ b/evaluation.py
@@ -262,7 +262,11 @@ def load_evaluation_set(path: str | Path) -> EvaluationSet:
         "manifest",
     )
     schema_version = _required(top_level, "schema_version", "schema_version")
-    if isinstance(schema_version, bool) or schema_version != EVALUATION_SCHEMA_VERSION:
+    if (
+        isinstance(schema_version, bool)
+        or not isinstance(schema_version, int)
+        or schema_version != EVALUATION_SCHEMA_VERSION
+    ):
         _config_error(
             "schema_version",
             f"must be {EVALUATION_SCHEMA_VERSION}",

--- a/evaluation.py
+++ b/evaluation.py
@@ -1,0 +1,680 @@
+"""Versioned scenario-evaluation contracts and scorecard aggregation."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Mapping
+
+
+EVALUATION_SCHEMA_VERSION = 1
+MAX_EVALUATION_RUNS = 100
+SUPPORTED_MODELS = ("historical", "gbm")
+SUPPORTED_SOURCE_MODES = ("auto", "offline", "online")
+
+_TICKER_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9.^=-]{0,14}$")
+
+
+class EvaluationConfigError(ValueError):
+    """Raised when an evaluation manifest cannot be safely expanded."""
+
+
+@dataclass(frozen=True)
+class EvaluationUniverse:
+    name: str
+    tickers: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {"name": self.name, "tickers": list(self.tickers)}
+
+
+@dataclass(frozen=True)
+class EvaluationSource:
+    name: str
+    mode: str
+    data_path: Path | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "mode": self.mode,
+            "data_path": str(self.data_path) if self.data_path is not None else None,
+        }
+
+
+@dataclass(frozen=True)
+class EvaluationSet:
+    name: str
+    days: int
+    scenarios: int
+    universes: tuple[EvaluationUniverse, ...]
+    models: tuple[str, ...]
+    seeds: tuple[int, ...]
+    sources: tuple[EvaluationSource, ...]
+    manifest_path: Path
+    manifest_sha256: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "days": self.days,
+            "scenarios": self.scenarios,
+            "universes": [universe.to_dict() for universe in self.universes],
+            "models": list(self.models),
+            "seeds": list(self.seeds),
+            "sources": [source.to_dict() for source in self.sources],
+            "manifest_path": str(self.manifest_path),
+            "manifest_sha256": self.manifest_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class EvaluationRun:
+    run_id: str
+    universe_name: str
+    tickers: tuple[str, ...]
+    model: str
+    seed: int
+    source_name: str
+    source_mode: str
+    data_path: Path | None
+    days: int
+    scenarios: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "run_id": self.run_id,
+            "universe_name": self.universe_name,
+            "tickers": list(self.tickers),
+            "model": self.model,
+            "seed": self.seed,
+            "source_name": self.source_name,
+            "source_mode": self.source_mode,
+            "data_path": str(self.data_path) if self.data_path is not None else None,
+            "days": self.days,
+            "scenarios": self.scenarios,
+        }
+
+
+@dataclass(frozen=True)
+class EvaluationRunOutcome:
+    run_id: str
+    universe_name: str
+    model: str
+    seed: int
+    source_name: str
+    source_mode: str
+    requested_tickers: int
+    completed_tickers: int
+    status: str
+    error: str | None
+    stance: str | None
+    top_pick: str | None
+    rank_order: tuple[str, ...]
+    guardrail_rejections: int
+    worst_var_95_pct: float | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "run_id": self.run_id,
+            "universe_name": self.universe_name,
+            "model": self.model,
+            "seed": self.seed,
+            "source_name": self.source_name,
+            "source_mode": self.source_mode,
+            "requested_tickers": self.requested_tickers,
+            "completed_tickers": self.completed_tickers,
+            "status": self.status,
+            "error": self.error,
+            "stance": self.stance,
+            "top_pick": self.top_pick,
+            "rank_order": list(self.rank_order),
+            "guardrail_rejections": self.guardrail_rejections,
+            "worst_var_95_pct": self.worst_var_95_pct,
+        }
+
+
+@dataclass(frozen=True)
+class EvaluationScorecard:
+    total_runs: int
+    completed_runs: int
+    failed_runs: int
+    run_success_rate: float
+    ticker_success_rate: float
+    mean_rank_correlation: float | None
+    top_pick_consistency: float | None
+    guardrail_rejection_rate: float
+    no_trade_rate: float
+    worst_var_95_pct: float | None
+    source_reliability: dict[str, dict[str, int | float]]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "total_runs": self.total_runs,
+            "completed_runs": self.completed_runs,
+            "failed_runs": self.failed_runs,
+            "run_success_rate": self.run_success_rate,
+            "ticker_success_rate": self.ticker_success_rate,
+            "mean_rank_correlation": self.mean_rank_correlation,
+            "top_pick_consistency": self.top_pick_consistency,
+            "guardrail_rejection_rate": self.guardrail_rejection_rate,
+            "no_trade_rate": self.no_trade_rate,
+            "worst_var_95_pct": self.worst_var_95_pct,
+            "source_reliability": self.source_reliability,
+        }
+
+
+@dataclass(frozen=True)
+class EvaluationReport:
+    schema_version: int
+    evaluation_set: EvaluationSet
+    generated_at: str
+    outcomes: tuple[EvaluationRunOutcome, ...]
+    scorecard: EvaluationScorecard
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "evaluation_set": self.evaluation_set.to_dict(),
+            "generated_at": self.generated_at,
+            "runs": [run.to_dict() for run in expand_evaluation_runs(self.evaluation_set)],
+            "outcomes": [outcome.to_dict() for outcome in self.outcomes],
+            "scorecard": self.scorecard.to_dict(),
+        }
+
+
+def _config_error(field: str, message: str, fix: str) -> None:
+    raise EvaluationConfigError(f"{field}: {message}. {fix}")
+
+
+def _strict_keys(value: object, allowed: set[str], field: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        _config_error(field, "must be an object", "Provide a JSON object")
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        _config_error(
+            field,
+            f"contains unsupported key {unknown[0]!r}",
+            "Remove unsupported keys",
+        )
+    return value
+
+
+def _nonempty_string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        _config_error(field, "must be a non-empty string", "Provide a non-empty string")
+    return value.strip()
+
+
+def _positive_int(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        _config_error(field, "must be a positive integer", "Provide an integer greater than zero")
+    return value
+
+
+def _required(mapping: Mapping[str, object], key: str, field: str) -> object:
+    if key not in mapping:
+        _config_error(field, "is required", "Provide this field")
+    return mapping[key]
+
+
+def _unique(values: tuple[object, ...], field: str) -> None:
+    if len(set(values)) != len(values):
+        _config_error(field, "contains duplicate values", "Use each value only once")
+
+
+def load_evaluation_set(path: str | Path) -> EvaluationSet:
+    """Load and strictly validate a version-one evaluation manifest."""
+
+    manifest_path = Path(path).resolve()
+    try:
+        manifest_bytes = manifest_path.read_bytes()
+    except OSError as exc:
+        raise EvaluationConfigError(
+            f"manifest_path: cannot read {manifest_path}. Provide a readable JSON manifest"
+        ) from exc
+    try:
+        document = json.loads(manifest_bytes)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise EvaluationConfigError(
+            "manifest: invalid JSON. Provide a valid JSON evaluation manifest"
+        ) from exc
+
+    top_level = _strict_keys(
+        document,
+        {
+            "schema_version",
+            "name",
+            "days",
+            "scenarios",
+            "universes",
+            "models",
+            "seeds",
+            "sources",
+        },
+        "manifest",
+    )
+    schema_version = _required(top_level, "schema_version", "schema_version")
+    if isinstance(schema_version, bool) or schema_version != EVALUATION_SCHEMA_VERSION:
+        _config_error(
+            "schema_version",
+            f"must be {EVALUATION_SCHEMA_VERSION}",
+            f"Use schema_version {EVALUATION_SCHEMA_VERSION}",
+        )
+
+    name = _nonempty_string(_required(top_level, "name", "name"), "name")
+    days = _positive_int(_required(top_level, "days", "days"), "days")
+    scenarios = _positive_int(
+        _required(top_level, "scenarios", "scenarios"), "scenarios"
+    )
+
+    raw_universes = _required(top_level, "universes", "universes")
+    if not isinstance(raw_universes, list) or not raw_universes:
+        _config_error("universes", "must be a non-empty array", "Provide at least one universe")
+    universes: list[EvaluationUniverse] = []
+    for index, raw_universe in enumerate(raw_universes):
+        field = f"universes[{index}]"
+        universe = _strict_keys(raw_universe, {"name", "tickers"}, field)
+        universe_name = _nonempty_string(
+            _required(universe, "name", f"{field}.name"), f"{field}.name"
+        )
+        raw_tickers = _required(universe, "tickers", f"{field}.tickers")
+        if not isinstance(raw_tickers, list) or not raw_tickers:
+            _config_error(
+                f"{field}.tickers",
+                "must be a non-empty array",
+                "Provide at least one ticker",
+            )
+        tickers: list[str] = []
+        for ticker_index, raw_ticker in enumerate(raw_tickers):
+            ticker_field = f"{field}.tickers[{ticker_index}]"
+            ticker = _nonempty_string(raw_ticker, ticker_field).upper()
+            if not _TICKER_PATTERN.fullmatch(ticker):
+                _config_error(
+                    ticker_field,
+                    "is not a supported ticker token",
+                    "Use 1-15 uppercase letters, digits, or .^=- characters",
+                )
+            tickers.append(ticker)
+        _unique(tuple(tickers), f"{field}.tickers")
+        universes.append(EvaluationUniverse(universe_name, tuple(tickers)))
+    _unique(tuple(universe.name for universe in universes), "universes.name")
+
+    raw_models = _required(top_level, "models", "models")
+    if not isinstance(raw_models, list) or not raw_models:
+        _config_error("models", "must be a non-empty array", "Provide at least one model")
+    models = tuple(_nonempty_string(value, "models") for value in raw_models)
+    for model in models:
+        if model not in SUPPORTED_MODELS:
+            _config_error(
+                "models",
+                f"contains unsupported model {model!r}",
+                f"Use one of {', '.join(SUPPORTED_MODELS)}",
+            )
+    _unique(models, "models")
+
+    raw_seeds = _required(top_level, "seeds", "seeds")
+    if not isinstance(raw_seeds, list) or not raw_seeds:
+        _config_error("seeds", "must be a non-empty array", "Provide at least one seed")
+    seeds: list[int] = []
+    for index, raw_seed in enumerate(raw_seeds):
+        if isinstance(raw_seed, bool) or not isinstance(raw_seed, int) or raw_seed < 0:
+            _config_error(
+                f"seeds[{index}]",
+                "must be a non-negative integer",
+                "Provide zero or a positive integer seed",
+            )
+        seeds.append(raw_seed)
+    _unique(tuple(seeds), "seeds")
+
+    raw_sources = _required(top_level, "sources", "sources")
+    if not isinstance(raw_sources, list) or not raw_sources:
+        _config_error("sources", "must be a non-empty array", "Provide at least one source")
+    sources: list[EvaluationSource] = []
+    for index, raw_source in enumerate(raw_sources):
+        field = f"sources[{index}]"
+        source = _strict_keys(raw_source, {"name", "mode", "data_path"}, field)
+        source_name = _nonempty_string(_required(source, "name", f"{field}.name"), f"{field}.name")
+        source_mode = _nonempty_string(_required(source, "mode", f"{field}.mode"), f"{field}.mode")
+        if source_mode not in SUPPORTED_SOURCE_MODES:
+            _config_error(
+                f"{field}.mode",
+                f"is unsupported mode {source_mode!r}",
+                f"Use one of {', '.join(SUPPORTED_SOURCE_MODES)}",
+            )
+        raw_data_path = source.get("data_path")
+        if source_mode == "offline" and raw_data_path is None:
+            _config_error(
+                f"{field}.data_path",
+                "is required for offline sources",
+                "Provide a local data_path",
+            )
+        if raw_data_path is not None and not isinstance(raw_data_path, str):
+            _config_error(
+                f"{field}.data_path",
+                "must be a string when provided",
+                "Provide a relative or absolute path string",
+            )
+        data_path = (
+            (manifest_path.parent / raw_data_path).resolve()
+            if isinstance(raw_data_path, str)
+            else None
+        )
+        sources.append(EvaluationSource(source_name, source_mode, data_path))
+    _unique(tuple(source.name for source in sources), "sources.name")
+
+    count = len(universes) * len(models) * len(seeds) * len(sources)
+    if count > MAX_EVALUATION_RUNS:
+        _config_error(
+            "runs",
+            f"expands to {count}, above the {MAX_EVALUATION_RUNS}-run limit",
+            "Reduce universes, models, seeds, or sources",
+        )
+
+    return EvaluationSet(
+        name=name,
+        days=days,
+        scenarios=scenarios,
+        universes=tuple(universes),
+        models=models,
+        seeds=tuple(seeds),
+        sources=tuple(sources),
+        manifest_path=manifest_path,
+        manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+    )
+
+
+def expand_evaluation_runs(evaluation_set: EvaluationSet) -> tuple[EvaluationRun, ...]:
+    """Expand an evaluation matrix in manifest order."""
+
+    runs: list[EvaluationRun] = []
+    for universe in evaluation_set.universes:
+        for model in evaluation_set.models:
+            for seed in evaluation_set.seeds:
+                for source in evaluation_set.sources:
+                    run_id = f"{universe.name}/{model}/seed-{seed}/{source.name}"
+                    runs.append(
+                        EvaluationRun(
+                            run_id=run_id,
+                            universe_name=universe.name,
+                            tickers=universe.tickers,
+                            model=model,
+                            seed=seed,
+                            source_name=source.name,
+                            source_mode=source.mode,
+                            data_path=source.data_path,
+                            days=evaluation_set.days,
+                            scenarios=evaluation_set.scenarios,
+                        )
+                    )
+    return tuple(runs)
+
+
+def _mapping_at(value: object, key: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        return {}
+    nested = value.get(key)
+    return nested if isinstance(nested, Mapping) else {}
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    return number if math.isfinite(number) else None
+
+
+def _failed_outcome(run: EvaluationRun, error: str) -> EvaluationRunOutcome:
+    return EvaluationRunOutcome(
+        run_id=run.run_id,
+        universe_name=run.universe_name,
+        model=run.model,
+        seed=run.seed,
+        source_name=run.source_name,
+        source_mode=run.source_mode,
+        requested_tickers=len(run.tickers),
+        completed_tickers=0,
+        status="failed",
+        error=error,
+        stance=None,
+        top_pick=None,
+        rank_order=(),
+        guardrail_rejections=0,
+        worst_var_95_pct=None,
+    )
+
+
+def _format_simulation_errors(errors: object) -> str:
+    if isinstance(errors, (list, tuple)):
+        messages: list[str] = []
+        for error in errors:
+            if isinstance(error, Mapping):
+                ticker = error.get("ticker")
+                message = error.get("error")
+                if ticker and message:
+                    messages.append(f"{ticker}: {message}")
+                    continue
+            if str(error):
+                messages.append(str(error))
+        return "; ".join(messages)
+    return str(errors) if errors else ""
+
+
+def _normalise_outcome(run: EvaluationRun, result: Mapping[str, object]) -> EvaluationRunOutcome:
+    report = _mapping_at(result, "report")
+    rankings = report.get("rankings")
+    errors = report.get("errors")
+    if not isinstance(rankings, Mapping) or not rankings:
+        message = _format_simulation_errors(errors) or "simulation returned no ranked tickers"
+        return _failed_outcome(run, message or "simulation returned no ranked tickers")
+
+    action_plan = _mapping_at(report, "action_plan")
+    primary_pick = action_plan.get("primary_pick")
+    top_pick = None
+    if isinstance(primary_pick, Mapping) and isinstance(primary_pick.get("ticker"), str):
+        top_pick = primary_pick["ticker"]
+    stance = action_plan.get("stance")
+    stance_value = stance if isinstance(stance, str) else None
+    results = report.get("results")
+    completed_tickers = len(results) if isinstance(results, Mapping) else 0
+    rank_order = tuple(str(ticker) for ticker in rankings)
+    guardrail_rejections = 0
+    downside_values: list[float] = []
+    for row in rankings.values():
+        if not isinstance(row, Mapping):
+            continue
+        if row.get("recommendation") == "AVOID" and row.get("guardrail_reasons"):
+            guardrail_rejections += 1
+        downside = _number(row.get("value_at_risk_95_pct"))
+        if downside is not None:
+            downside_values.append(downside)
+    return EvaluationRunOutcome(
+        run_id=run.run_id,
+        universe_name=run.universe_name,
+        model=run.model,
+        seed=run.seed,
+        source_name=run.source_name,
+        source_mode=run.source_mode,
+        requested_tickers=len(run.tickers),
+        completed_tickers=completed_tickers,
+        status="completed",
+        error=None,
+        stance=stance_value,
+        top_pick=top_pick,
+        rank_order=rank_order,
+        guardrail_rejections=guardrail_rejections,
+        worst_var_95_pct=max(downside_values) if downside_values else None,
+    )
+
+
+def _rank_correlation(left: tuple[str, ...], right: tuple[str, ...]) -> float | None:
+    common = [ticker for ticker in left if ticker in set(right)]
+    if len(common) < 2:
+        return None
+    left_positions = {ticker: index + 1 for index, ticker in enumerate(left)}
+    right_positions = {ticker: index + 1 for index, ticker in enumerate(right)}
+    values_left = [left_positions[ticker] for ticker in common]
+    values_right = [right_positions[ticker] for ticker in common]
+    mean_left = sum(values_left) / len(values_left)
+    mean_right = sum(values_right) / len(values_right)
+    numerator = sum(
+        (left_value - mean_left) * (right_value - mean_right)
+        for left_value, right_value in zip(values_left, values_right)
+    )
+    denominator_left = sum((value - mean_left) ** 2 for value in values_left)
+    denominator_right = sum((value - mean_right) ** 2 for value in values_right)
+    denominator = math.sqrt(denominator_left * denominator_right)
+    return numerator / denominator if denominator else None
+
+
+def _scorecard(outcomes: tuple[EvaluationRunOutcome, ...]) -> EvaluationScorecard:
+    total_runs = len(outcomes)
+    completed = tuple(outcome for outcome in outcomes if outcome.status == "completed")
+    completed_runs = len(completed)
+    requested_tickers = sum(outcome.requested_tickers for outcome in outcomes)
+    completed_tickers = sum(outcome.completed_tickers for outcome in completed)
+    correlations: list[float] = []
+    outcomes_by_universe: dict[str, list[EvaluationRunOutcome]] = {}
+    for outcome in completed:
+        outcomes_by_universe.setdefault(outcome.universe_name, []).append(outcome)
+    for universe_outcomes in outcomes_by_universe.values():
+        for index, left in enumerate(universe_outcomes):
+            for right in universe_outcomes[index + 1 :]:
+                correlation = _rank_correlation(left.rank_order, right.rank_order)
+                if correlation is not None:
+                    correlations.append(correlation)
+    consistency: list[float] = []
+    for universe_outcomes in outcomes_by_universe.values():
+        picks = Counter(outcome.top_pick for outcome in universe_outcomes)
+        consistency.append(max(picks.values()) / len(universe_outcomes))
+    guardrails = sum(outcome.guardrail_rejections for outcome in completed)
+    downside_values = [
+        outcome.worst_var_95_pct
+        for outcome in completed
+        if outcome.worst_var_95_pct is not None
+    ]
+    source_reliability: dict[str, dict[str, int | float]] = {}
+    for source_name in dict.fromkeys(outcome.source_name for outcome in outcomes):
+        source_outcomes = [
+            outcome for outcome in outcomes if outcome.source_name == source_name
+        ]
+        source_completed = sum(
+            outcome.status == "completed" for outcome in source_outcomes
+        )
+        source_total = len(source_outcomes)
+        source_reliability[source_name] = {
+            "total_runs": source_total,
+            "completed_runs": source_completed,
+            "failed_runs": source_total - source_completed,
+            "run_success_rate": source_completed / source_total if source_total else 0.0,
+        }
+    return EvaluationScorecard(
+        total_runs=total_runs,
+        completed_runs=completed_runs,
+        failed_runs=total_runs - completed_runs,
+        run_success_rate=completed_runs / total_runs if total_runs else 0.0,
+        ticker_success_rate=(
+            completed_tickers / requested_tickers if requested_tickers else 0.0
+        ),
+        mean_rank_correlation=(sum(correlations) / len(correlations) if correlations else None),
+        top_pick_consistency=(sum(consistency) / len(consistency) if consistency else None),
+        guardrail_rejection_rate=(
+            guardrails / completed_tickers if completed_tickers else 0.0
+        ),
+        no_trade_rate=(
+            sum(outcome.stance == "NO_TRADE" for outcome in completed) / completed_runs
+            if completed_runs
+            else 0.0
+        ),
+        worst_var_95_pct=max(downside_values) if downside_values else None,
+        source_reliability=source_reliability,
+    )
+
+
+def evaluate_scenario_set(
+    evaluation_set: EvaluationSet,
+    runner: Callable[[EvaluationRun], Mapping[str, object]],
+) -> EvaluationReport:
+    """Run a deterministic matrix, isolating each simulation failure."""
+
+    outcomes: list[EvaluationRunOutcome] = []
+    for run in expand_evaluation_runs(evaluation_set):
+        try:
+            result = runner(run)
+            if not isinstance(result, Mapping):
+                raise TypeError("runner returned a non-mapping result")
+            outcomes.append(_normalise_outcome(run, result))
+        except Exception as exc:
+            outcomes.append(_failed_outcome(run, str(exc) or type(exc).__name__))
+    frozen_outcomes = tuple(outcomes)
+    return EvaluationReport(
+        schema_version=EVALUATION_SCHEMA_VERSION,
+        evaluation_set=evaluation_set,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        outcomes=frozen_outcomes,
+        scorecard=_scorecard(frozen_outcomes),
+    )
+
+
+def _percentage(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.1%}"
+
+
+def format_evaluation_scorecard(report: EvaluationReport) -> str:
+    """Render the concise, operator-facing evaluation scorecard."""
+
+    scorecard = report.scorecard
+    lines = [
+        f"Evaluation set: {report.evaluation_set.name}",
+        (
+            f"Runs: {scorecard.completed_runs}/{scorecard.total_runs} complete "
+            f"({_percentage(scorecard.run_success_rate)})"
+        ),
+        f"Ticker coverage: {_percentage(scorecard.ticker_success_rate)}",
+        f"Mean rank correlation: {_percentage(scorecard.mean_rank_correlation)}",
+        f"Top-pick consistency: {_percentage(scorecard.top_pick_consistency)}",
+        f"Guardrail rejections: {_percentage(scorecard.guardrail_rejection_rate)}",
+        f"No-trade runs: {_percentage(scorecard.no_trade_rate)}",
+        f"Worst observed 95% downside: {_percentage(scorecard.worst_var_95_pct)}",
+        "Source reliability:",
+    ]
+    for source_name, reliability in scorecard.source_reliability.items():
+        lines.append(
+            f"  {source_name}: {reliability['completed_runs']}/"
+            f"{reliability['total_runs']} complete "
+            f"({_percentage(float(reliability['run_success_rate']))})"
+        )
+    return "\n".join(lines)
+
+
+def save_evaluation_report(
+    report: EvaluationReport,
+    output_dir: str | Path,
+) -> tuple[Path, Path, Path]:
+    """Persist a scorecard, ordered run rows, and machine-readable report."""
+
+    directory = Path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    scorecard_path = directory / "scorecard.md"
+    runs_path = directory / "runs.csv"
+    report_path = directory / "report.json"
+    scorecard_path.write_text(format_evaluation_scorecard(report) + "\n", encoding="utf-8")
+    fieldnames = list(EvaluationRunOutcome.__dataclass_fields__)
+    with runs_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for outcome in report.outcomes:
+            row = outcome.to_dict()
+            row["rank_order"] = " > ".join(outcome.rank_order)
+            writer.writerow(row)
+    with report_path.open("w", encoding="utf-8") as handle:
+        json.dump(report.to_dict(), handle, indent=2)
+        handle.write("\n")
+    return scorecard_path, runs_path, report_path

--- a/evaluation_sets/sample-stability.json
+++ b/evaluation_sets/sample-stability.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "name": "sample-stability",
+  "days": 5,
+  "scenarios": 100,
+  "universes": [
+    {
+      "name": "large-cap-tech",
+      "tickers": ["AAPL", "MSFT"]
+    }
+  ],
+  "models": ["historical", "gbm"],
+  "seeds": [7, 42, 99],
+  "sources": [
+    {
+      "name": "bundled",
+      "mode": "offline",
+      "data_path": "../sample_data"
+    }
+  ]
+}

--- a/public_cli.py
+++ b/public_cli.py
@@ -13,6 +13,14 @@ import pandas as pd
 
 import backtest as backtest_cli
 from data import PriceDataError
+from evaluation import (
+    EvaluationReport,
+    EvaluationRun,
+    evaluate_scenario_set,
+    format_evaluation_scorecard,
+    load_evaluation_set,
+    save_evaluation_report,
+)
 from cli_shared import (
     IntentionalDefaultsHelpFormatter,
     non_negative_int,
@@ -198,6 +206,21 @@ def build_public_parser() -> argparse.ArgumentParser:
         help="Print tables and secondary metrics.",
     )
 
+    evaluate_parser = subparsers.add_parser(
+        "evaluate",
+        help="Test decision stability across a reproducible scenario set.",
+        formatter_class=IntentionalDefaultsHelpFormatter,
+    )
+    evaluate_parser.add_argument(
+        "set_file",
+        help="Versioned JSON evaluation-set file.",
+    )
+    evaluate_parser.add_argument(
+        "--output",
+        default=None,
+        help="Directory for scorecard.md, runs.csv, and report.json.",
+    )
+
     return parser
 
 
@@ -206,7 +229,7 @@ def _parse_public_args_with_parser(
 ) -> tuple[argparse.ArgumentParser, argparse.Namespace]:
     parser = build_public_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
-    if getattr(args, "command", None) and not args.tickers:
+    if getattr(args, "command", None) in {"simulate", "backtest"} and not args.tickers:
         args.tickers = ["AAPL"]
     return parser, args
 
@@ -532,6 +555,32 @@ def execute_public_backtest(args: argparse.Namespace) -> dict[str, object]:
     return backtest_cli.run(legacy_args, render=False)
 
 
+def _execute_evaluation_run(run: EvaluationRun) -> dict[str, Any]:
+    """Adapt one evaluation matrix cell to the public simulation interface."""
+
+    return execute_public_simulate(
+        argparse.Namespace(
+            tickers=list(run.tickers),
+            days=run.days,
+            scenarios=run.scenarios,
+            model=run.model,
+            seed=run.seed,
+            source=run.source_mode,
+            data_path=str(run.data_path) if run.data_path is not None else None,
+            output=None,
+            show=False,
+            details=False,
+        )
+    )
+
+
+def execute_public_evaluate(args: argparse.Namespace) -> EvaluationReport:
+    """Execute an evaluation set without rendering text output."""
+
+    evaluation_set = load_evaluation_set(args.set_file)
+    return evaluate_scenario_set(evaluation_set, _execute_evaluation_run)
+
+
 def run_public_simulate(args: argparse.Namespace) -> dict[str, Any]:
     """Execute the simplified simulate command."""
 
@@ -558,13 +607,26 @@ def run_public_backtest(args: argparse.Namespace) -> dict[str, object]:
     return result
 
 
+def run_public_evaluate(args: argparse.Namespace) -> EvaluationReport:
+    """Execute and render a reproducible decision-stability evaluation."""
+
+    report = execute_public_evaluate(args)
+    print(format_evaluation_scorecard(report))
+    if args.output:
+        save_evaluation_report(report, args.output)
+    return report
+
+
 def main(argv: Optional[Iterable[str]] = None) -> int:
     """Entrypoint for the public ``monte-carlo`` command."""
 
     parser, args = _parse_public_args_with_parser(argv)
     if args.command is None:
         parser.print_help()
-        print("\nChoose `simulate` for current ideas or `backtest` for historical validation.")
+        print(
+            "\nChoose `simulate` for current ideas, `backtest` for historical "
+            "validation, or `evaluate` for decision stability."
+        )
         return 1
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
@@ -578,8 +640,15 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         if args.command == "backtest":
             run_public_backtest(args)
             return 0
+        if args.command == "evaluate":
+            report = run_public_evaluate(args)
+            return 1 if report.scorecard.failed_runs > 0 else 0
     except Exception as exc:
         _log_public_error(exc, command=str(args.command), args=args)
         return 2
 
     return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["flake8", "pytest"]
+dev = ["flake8", "pytest", "setuptools>=69", "wheel"]
 ui = []
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,4 @@ monte-carlo = "public_cli:main"
 monte-carlo-ui = "web_entrypoint:main"
 
 [tool.setuptools]
-py-modules = ["analysis", "ai", "backtest", "cli", "cli_shared", "data", "decision", "legacy_cli", "public_cli", "simulate_cli", "simulation", "ui_bridge", "ui_state", "viz", "web_entrypoint"]
+py-modules = ["analysis", "ai", "backtest", "cli", "cli_shared", "data", "decision", "evaluation", "legacy_cli", "public_cli", "simulate_cli", "simulation", "ui_bridge", "ui_state", "viz", "web_entrypoint"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ import cli as cli_module  # noqa: E402
 import data  # noqa: E402
 import MonteCarlo  # noqa: E402
 import simulate_cli  # noqa: E402
+from evaluation import EvaluationReport, EvaluationScorecard  # noqa: E402
 from cli import legacy_main, parse_args, run  # noqa: E402
 from public_cli import (  # noqa: E402
     main,
@@ -36,6 +37,76 @@ def test_public_parse_args_defaults_to_aapl():
     args = parse_public_args(["simulate"])
     assert args.command == "simulate"
     assert args.tickers == ["AAPL"]
+
+
+def test_public_parser_accepts_evaluation_set_and_output():
+    args = parse_public_args(
+        ["evaluate", "evaluation_sets/sample-stability.json", "--output", "results/eval"]
+    )
+
+    assert args.command == "evaluate"
+    assert args.set_file == "evaluation_sets/sample-stability.json"
+    assert args.output == "results/eval"
+
+
+def test_public_evaluate_runs_reference_set_and_writes_auditable_outputs(tmp_path, capsys):
+    output = tmp_path / "evaluation"
+
+    exit_code = main(
+        [
+            "evaluate",
+            "evaluation_sets/sample-stability.json",
+            "--output",
+            str(output),
+        ]
+    )
+
+    rendered = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Evaluation set: sample-stability" in rendered
+    assert "Runs: 6/6 complete (100.0%)" in rendered
+    assert {path.name for path in output.iterdir()} == {
+        "scorecard.md",
+        "runs.csv",
+        "report.json",
+    }
+
+
+def test_public_evaluate_returns_one_when_scorecard_has_failed_runs(monkeypatch):
+    failed_report = object.__new__(EvaluationReport)
+    object.__setattr__(
+        failed_report,
+        "scorecard",
+        EvaluationScorecard(
+            total_runs=1,
+            completed_runs=0,
+            failed_runs=1,
+            run_success_rate=0.0,
+            ticker_success_rate=0.0,
+            mean_rank_correlation=None,
+            top_pick_consistency=None,
+            guardrail_rejection_rate=0.0,
+            no_trade_rate=0.0,
+            worst_var_95_pct=None,
+            source_reliability={},
+        ),
+    )
+    monkeypatch.setattr("public_cli.run_public_evaluate", lambda _args: failed_report)
+
+    assert main(["evaluate", "set.json"]) == 1
+
+
+def test_public_evaluate_returns_actionable_error_for_malformed_manifest(
+    tmp_path, caplog
+):
+    set_file = tmp_path / "malformed.json"
+    set_file.write_text("{", encoding="utf-8")
+
+    with caplog.at_level(logging.ERROR, logger="public_cli"):
+        exit_code = main(["evaluate", str(set_file)])
+
+    assert exit_code == 2
+    assert "invalid JSON" in caplog.text
 
 
 def test_public_main_without_subcommand_prints_help_hint(capsys):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from evaluation import expand_evaluation_runs, load_evaluation_set
 from public_cli import main as public_main
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -24,6 +25,12 @@ def test_contributor_guides_describe_public_cli_split() -> None:
     for path in ("AGENTS.md",):
         text = Path(path).read_text(encoding="utf-8")
         assert "public_cli.py" in text
+
+
+def test_contributor_guides_name_evaluation_contract_and_reference_sets() -> None:
+    text = Path("AGENTS.md").read_text(encoding="utf-8")
+    assert "evaluation.py" in text
+    assert "evaluation_sets/" in text
 
 
 def test_improvements_doc_avoids_retired_command_examples() -> None:
@@ -59,6 +66,15 @@ def test_readme_links_output_guide_and_stays_operator_focused() -> None:
     assert "monte-carlo backtest" in text
 
 
+def test_readme_documents_evaluation_gate_before_capital_is_risked() -> None:
+    text = README_PATH.read_text(encoding="utf-8")
+    assert (
+        "monte-carlo evaluate evaluation_sets/sample-stability.json "
+        "--output results/evaluation"
+    ) in text
+    assert "before capital is risked" in text
+
+
 def test_output_guide_names_key_saved_artifacts() -> None:
     text = OUTPUT_GUIDE_PATH.read_text(encoding="utf-8")
     for artifact in (
@@ -76,6 +92,22 @@ def test_output_guide_names_key_saved_artifacts() -> None:
         assert artifact in text
     assert "execution_plan.csv" not in text
     assert "simulations.csv.gz" not in text
+
+
+def test_output_guide_explains_evaluation_artifacts() -> None:
+    text = OUTPUT_GUIDE_PATH.read_text(encoding="utf-8")
+    assert "scorecard.md" in text
+    assert "runs.csv" in text
+    assert "manifest hash" in text
+    assert "normalized matrix" in text
+    assert "source reliability" in text
+
+
+def test_reference_evaluation_set_expands_to_bundled_sample_data() -> None:
+    evaluation_set = load_evaluation_set("evaluation_sets/sample-stability.json")
+
+    assert len(expand_evaluation_runs(evaluation_set)) == 6
+    assert evaluation_set.sources[0].data_path == (REPO_ROOT / "sample_data").resolve()
 
 
 def test_readme_offline_examples_run(capsys) -> None:

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -116,6 +116,7 @@ def test_load_evaluation_set_resolves_paths_and_expands_in_manifest_order(tmp_pa
         (lambda data: data.update({"unexpected": True}), "unexpected"),
         (lambda data: data.pop("schema_version"), "schema_version"),
         (lambda data: data.update({"schema_version": 2}), "schema_version"),
+        (lambda data: data.update({"schema_version": 1.0}), "schema_version"),
         (lambda data: data.update({"models": ["historical", "historical"]}), "models"),
         (lambda data: data.update({"universes": []}), "universes"),
         (lambda data: data["universes"][0].update({"tickers": []}), "tickers"),

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -8,6 +8,7 @@ import pytest
 
 from evaluation import (
     EvaluationConfigError,
+    _rank_correlation,
     evaluate_scenario_set,
     expand_evaluation_runs,
     format_evaluation_scorecard,
@@ -146,6 +147,41 @@ def test_load_evaluation_set_rejects_invalid_manifests(tmp_path, mutate, field):
     assert any(word in message for word in ("Provide", "Use", "Remove", "Reduce"))
 
 
+def test_load_evaluation_set_rejects_names_that_can_collide_in_run_ids(tmp_path):
+    payload = base_set()
+    payload["universes"] = [
+        {"name": "core", "tickers": ["AAPL"]},
+        {"name": "core/historical/seed-7/bundled", "tickers": ["MSFT"]},
+    ]
+    payload["seeds"] = [7]
+    payload["sources"] = [
+        {
+            "name": "bundled/historical/seed-7/local",
+            "mode": "offline",
+            "data_path": "prices",
+        },
+        {"name": "local", "mode": "offline", "data_path": "prices"},
+    ]
+
+    with pytest.raises(EvaluationConfigError) as exc:
+        load_evaluation_set(write_set(tmp_path, payload))
+
+    assert "name" in str(exc.value)
+    assert "safe token" in str(exc.value)
+
+
+def test_load_evaluation_set_normalizes_non_utf_manifest_errors(tmp_path):
+    path = tmp_path / "evaluation.json"
+    path.write_bytes(b'{"schema_version": 1, "name": "\xff"}')
+
+    with pytest.raises(EvaluationConfigError) as exc:
+        load_evaluation_set(path)
+
+    assert str(exc.value) == (
+        "manifest: invalid JSON. Provide a valid JSON evaluation manifest"
+    )
+
+
 def test_evaluate_scenario_set_reports_stability_reliability_and_downside(tmp_path):
     evaluation_set = load_evaluation_set(write_two_seed_set(tmp_path))
 
@@ -177,6 +213,66 @@ def test_evaluate_scenario_set_reports_stability_reliability_and_downside(tmp_pa
     assert report.scorecard.guardrail_rejection_rate == pytest.approx(0.25)
     assert report.scorecard.no_trade_rate == pytest.approx(0.0)
     assert report.scorecard.worst_var_95_pct == pytest.approx(0.20)
+    assert report.scorecard.source_reliability["bundled"]["completed_runs"] == 2
+
+
+def test_evaluation_counts_defensive_hold_cash_as_no_trade(tmp_path):
+    payload = base_set()
+    payload["seeds"] = [7]
+    evaluation_set = load_evaluation_set(write_set(tmp_path, payload))
+
+    report = evaluate_scenario_set(
+        evaluation_set,
+        lambda run: simulation_result(
+            rankings=[
+                ("AAPL", -1.0, "AVOID", "expected_return<0.0%", 0.08),
+                ("MSFT", -2.0, "AVOID", "expected_return<0.0%", 0.14),
+            ],
+            top_pick=None,
+            stance="DEFENSIVE",
+        ),
+    )
+
+    assert report.outcomes[0].status == "completed"
+    assert report.outcomes[0].top_pick is None
+    assert report.scorecard.no_trade_rate == pytest.approx(1.0)
+
+
+def test_rank_correlation_hashes_a_large_right_universe_once():
+    class CountingTicker(str):
+        hash_calls = 0
+
+        def __hash__(self):
+            type(self).hash_calls += 1
+            return super().__hash__()
+
+    left = tuple(CountingTicker(f"T{index:03}") for index in range(250))
+    right = tuple(reversed(left))
+
+    correlation = _rank_correlation(left, right)
+
+    assert correlation == pytest.approx(-1.0)
+    assert CountingTicker.hash_calls < 5_000
+
+
+def test_scorecard_source_reliability_is_recursively_immutable(tmp_path):
+    evaluation_set = load_evaluation_set(write_two_seed_set(tmp_path))
+    report = evaluate_scenario_set(
+        evaluation_set,
+        lambda run: simulation_result(
+            rankings=[("AAPL", 1.0, "BUY", "", 0.08)],
+            top_pick="AAPL",
+            stance="SELECTIVE",
+        ),
+    )
+
+    with pytest.raises(TypeError):
+        report.scorecard.source_reliability["new"] = {}
+    with pytest.raises(TypeError):
+        report.scorecard.source_reliability["bundled"]["completed_runs"] = 0
+
+    serialized = report.scorecard.to_dict()
+    serialized["source_reliability"]["bundled"]["completed_runs"] = 0
     assert report.scorecard.source_reliability["bundled"]["completed_runs"] == 2
 
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from evaluation import (
+    EvaluationConfigError,
+    evaluate_scenario_set,
+    expand_evaluation_runs,
+    format_evaluation_scorecard,
+    load_evaluation_set,
+    save_evaluation_report,
+)
+
+
+def write_set(tmp_path: Path, payload: dict[str, object]) -> Path:
+    path = tmp_path / "evaluation.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def base_set() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "name": "sample-stability",
+        "days": 20,
+        "scenarios": 250,
+        "universes": [{"name": "core", "tickers": ["AAPL", "MSFT"]}],
+        "models": ["historical"],
+        "seeds": [7, 42],
+        "sources": [{"name": "bundled", "mode": "offline", "data_path": "prices"}],
+    }
+
+
+def write_two_seed_set(tmp_path: Path) -> Path:
+    return write_set(tmp_path, base_set())
+
+
+def simulation_result(
+    *,
+    rankings: list[tuple[str, float, str, str, float]],
+    top_pick: str | None,
+    stance: str,
+    errors: list[str] | None = None,
+) -> dict[str, object]:
+    ranking_data = {
+        ticker: {
+            "score": score,
+            "recommendation": recommendation,
+            "guardrail_reasons": reasons,
+            "value_at_risk_95_pct": downside,
+        }
+        for ticker, score, recommendation, reasons, downside in rankings
+    }
+    return {
+        "report": {
+            "rankings": ranking_data,
+            "action_plan": {
+                "stance": stance,
+                "primary_pick": None if top_pick is None else {"ticker": top_pick},
+            },
+            "results": {ticker: {"summary": {}} for ticker in ranking_data},
+            "errors": [] if errors is None else errors,
+        },
+        "price_sources": {
+            ticker: {"mode": "offline", "detail": "fixture"}
+            for ticker in ranking_data
+        },
+    }
+
+
+def test_load_evaluation_set_resolves_paths_and_expands_in_manifest_order(tmp_path):
+    set_path = write_set(
+        tmp_path,
+        {
+            "schema_version": 1,
+            "name": "core-stability",
+            "days": 20,
+            "scenarios": 250,
+            "universes": [
+                {"name": "tech", "tickers": ["aapl", "MSFT"]},
+                {"name": "single", "tickers": ["JPM"]},
+            ],
+            "models": ["historical", "gbm"],
+            "seeds": [7, 42],
+            "sources": [
+                {"name": "bundled", "mode": "offline", "data_path": "../prices"},
+                {"name": "live", "mode": "online"},
+            ],
+        },
+    )
+
+    evaluation_set = load_evaluation_set(set_path)
+    runs = expand_evaluation_runs(evaluation_set)
+
+    assert len(runs) == 16
+    assert evaluation_set.universes[0].tickers == ("AAPL", "MSFT")
+    assert evaluation_set.sources[0].data_path == (tmp_path / "../prices").resolve()
+    assert [
+        (run.universe_name, run.model, run.seed, run.source_name)
+        for run in runs[:4]
+    ] == [
+        ("tech", "historical", 7, "bundled"),
+        ("tech", "historical", 7, "live"),
+        ("tech", "historical", 42, "bundled"),
+        ("tech", "historical", 42, "live"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("mutate", "field"),
+    [
+        (lambda data: data.update({"unexpected": True}), "unexpected"),
+        (lambda data: data.pop("schema_version"), "schema_version"),
+        (lambda data: data.update({"schema_version": 2}), "schema_version"),
+        (lambda data: data.update({"models": ["historical", "historical"]}), "models"),
+        (lambda data: data.update({"universes": []}), "universes"),
+        (lambda data: data["universes"][0].update({"tickers": []}), "tickers"),
+        (lambda data: data.update({"models": []}), "models"),
+        (lambda data: data.update({"seeds": []}), "seeds"),
+        (lambda data: data.update({"sources": []}), "sources"),
+        (lambda data: data["universes"][0].update({"tickers": ["BAD TICKER"]}), "tickers"),
+        (lambda data: data.update({"seeds": [-1]}), "seeds"),
+        (lambda data: data.update({"seeds": [True]}), "seeds"),
+        (lambda data: data.update({"models": ["prediction"]}), "models"),
+        (lambda data: data["sources"][0].update({"mode": "invalid"}), "mode"),
+        (lambda data: data["sources"][0].pop("data_path"), "data_path"),
+        (lambda data: data.update({"days": 0}), "days"),
+        (lambda data: data.update({"scenarios": False}), "scenarios"),
+        (lambda data: data.update({"seeds": list(range(101))}), "runs"),
+    ],
+)
+def test_load_evaluation_set_rejects_invalid_manifests(tmp_path, mutate, field):
+    payload = base_set()
+    mutate(payload)
+
+    with pytest.raises(EvaluationConfigError) as exc:
+        load_evaluation_set(write_set(tmp_path, payload))
+
+    message = str(exc.value)
+    assert field in message
+    assert any(word in message for word in ("Provide", "Use", "Remove", "Reduce"))
+
+
+def test_evaluate_scenario_set_reports_stability_reliability_and_downside(tmp_path):
+    evaluation_set = load_evaluation_set(write_two_seed_set(tmp_path))
+
+    def runner(run):
+        if run.seed == 7:
+            return simulation_result(
+                rankings=[
+                    ("AAPL", 12.0, "BUY", "", 0.08),
+                    ("MSFT", 8.0, "AVOID", "expected_return<0.0%", 0.14),
+                ],
+                top_pick="AAPL",
+                stance="SELECTIVE",
+            )
+        return simulation_result(
+            rankings=[
+                ("MSFT", 11.0, "BUY", "", 0.10),
+                ("AAPL", 9.0, "BUY", "", 0.20),
+            ],
+            top_pick="MSFT",
+            stance="RISK_ON",
+        )
+
+    report = evaluate_scenario_set(evaluation_set, runner)
+
+    assert report.scorecard.run_success_rate == pytest.approx(1.0)
+    assert report.scorecard.ticker_success_rate == pytest.approx(1.0)
+    assert report.scorecard.mean_rank_correlation == pytest.approx(-1.0)
+    assert report.scorecard.top_pick_consistency == pytest.approx(0.5)
+    assert report.scorecard.guardrail_rejection_rate == pytest.approx(0.25)
+    assert report.scorecard.no_trade_rate == pytest.approx(0.0)
+    assert report.scorecard.worst_var_95_pct == pytest.approx(0.20)
+    assert report.scorecard.source_reliability["bundled"]["completed_runs"] == 2
+
+
+def test_evaluation_isolates_runner_errors_and_empty_rankings(tmp_path):
+    evaluation_set = load_evaluation_set(write_two_seed_set(tmp_path))
+
+    def runner(run):
+        if run.seed == 7:
+            raise RuntimeError("fixture exploded")
+        return simulation_result(
+            rankings=[],
+            top_pick=None,
+            stance="DEFENSIVE",
+            errors=[
+                {"ticker": "AAPL", "error": "no data"},
+                {"ticker": "MSFT", "error": "bad history"},
+            ],
+        )
+
+    report = evaluate_scenario_set(evaluation_set, runner)
+
+    assert [outcome.status for outcome in report.outcomes] == ["failed", "failed"]
+    assert report.outcomes[0].error == "fixture exploded"
+    assert report.outcomes[1].error == "AAPL: no data; MSFT: bad history"
+    assert report.scorecard.completed_runs == 0
+
+
+def test_evaluation_rank_correlation_and_format_handle_unavailable_metrics(tmp_path):
+    payload = base_set()
+    payload["seeds"] = [7]
+    evaluation_set = load_evaluation_set(write_set(tmp_path, payload))
+    report = evaluate_scenario_set(
+        evaluation_set,
+        lambda run: simulation_result(
+            rankings=[("AAPL", 1.0, "BUY", "", 0.08)],
+            top_pick="AAPL",
+            stance="SELECTIVE",
+        ),
+    )
+
+    assert report.scorecard.mean_rank_correlation is None
+    assert "Mean rank correlation: n/a" in format_evaluation_scorecard(report)
+
+
+def test_save_evaluation_report_persists_scorecard_runs_and_report(tmp_path):
+    evaluation_set = load_evaluation_set(write_two_seed_set(tmp_path))
+    report = evaluate_scenario_set(
+        evaluation_set,
+        lambda run: simulation_result(
+            rankings=[
+                ("AAPL", 1.0, "BUY", "", 0.08),
+                ("MSFT", 0.5, "AVOID", "risk", 0.14),
+            ],
+            top_pick="AAPL",
+            stance="SELECTIVE",
+        ),
+    )
+
+    scorecard_path, runs_path, report_path = save_evaluation_report(
+        report, tmp_path / "nested" / "outputs"
+    )
+
+    assert [path.name for path in (scorecard_path, runs_path, report_path)] == [
+        "scorecard.md",
+        "runs.csv",
+        "report.json",
+    ]
+    assert scorecard_path.read_text(encoding="utf-8") == (
+        format_evaluation_scorecard(report) + "\n"
+    )
+    with report_path.open(encoding="utf-8") as handle:
+        persisted = json.load(handle)
+    assert persisted["evaluation_set"]["name"] == "sample-stability"
+    assert persisted["scorecard"]["completed_runs"] == 2
+    with runs_path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert len(rows) == 2
+    assert rows[0]["rank_order"] == "AAPL > MSFT"

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -113,6 +114,76 @@ def test_installed_entrypoint_runs_offline_simulate_and_backtest() -> None:
     assert backtest.returncode == 0, backtest.stderr
     assert "Strategy return:" in backtest.stdout
     assert "Backtest summary" in backtest.stdout
+
+
+def test_built_wheel_keeps_reference_assets_source_checkout_only(tmp_path) -> None:
+    wheel_dir = tmp_path / "dist"
+    wheel_dir.mkdir()
+    built = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            str(REPO_ROOT),
+            "--no-deps",
+            "--no-build-isolation",
+            "--wheel-dir",
+            str(wheel_dir),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=tmp_path,
+        text=True,
+    )
+    assert built.returncode == 0, built.stderr
+    wheel_path = next(wheel_dir.glob("*.whl"))
+    with zipfile.ZipFile(wheel_path) as wheel:
+        packaged_paths = set(wheel.namelist())
+    assert "evaluation.py" in packaged_paths
+    assert not any(path.startswith("evaluation_sets/") for path in packaged_paths)
+    assert not any(path.startswith("sample_data/") for path in packaged_paths)
+
+    installed_dir = tmp_path / "site"
+    installed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-deps",
+            "--target",
+            str(installed_dir),
+            str(wheel_path),
+        ],
+        capture_output=True,
+        check=False,
+        cwd=tmp_path,
+        text=True,
+    )
+    assert installed.returncode == 0, installed.stderr
+    evaluated = subprocess.run(
+        [
+            sys.executable,
+            str(installed_dir / "public_cli.py"),
+            "evaluate",
+            "evaluation_sets/sample-stability.json",
+        ],
+        capture_output=True,
+        check=False,
+        cwd=tmp_path,
+        env={**os.environ, "MPLBACKEND": "Agg"},
+        text=True,
+    )
+    assert evaluated.returncode == 2
+    assert "cannot read" in f"{evaluated.stdout}\n{evaluated.stderr}"
+
+    readme = " ".join(
+        (REPO_ROOT / "README.md").read_text(encoding="utf-8").lower().split()
+    )
+    assert "source-checkout assets" in readme
+    assert "not included in the installed wheel" in readme
+    assert "supply their own evaluation-set json and local data paths" in readme
 
 
 def test_pyproject_console_script_points_to_public_cli() -> None:

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -46,6 +46,7 @@ def test_installed_entrypoint_serves_help_commands() -> None:
         ["--help"],
         ["simulate", "--help"],
         ["backtest", "--help"],
+        ["evaluate", "--help"],
     ):
         completed = _run_entrypoint(entrypoint, *args)
         assert completed.returncode == 0, completed.stderr
@@ -59,6 +60,7 @@ def test_installed_entrypoint_without_subcommand_prints_help_hint() -> None:
     assert completed.returncode == 1, completed.stderr
     assert "simulate" in completed.stdout
     assert "backtest" in completed.stdout
+    assert "evaluate" in completed.stdout
     assert "Choose `simulate` for current ideas" in completed.stdout
 
 


### PR DESCRIPTION
## Summary

- add `monte-carlo evaluate` for reproducible scenario sets across universes, models, seeds, and data sources
- report ranking stability, source reliability, guardrail rejection, no-trade behavior, and observed downside
- persist `scorecard.md`, `runs.csv`, and `report.json` with exact manifest provenance
- include a deterministic six-run offline reference set and operator documentation

## Why

One-off Monte Carlo rankings can vary with model, seed, universe, and source behavior. This adds a bounded evidence gate before capital is risked while reusing the existing simulation engine and adding no runtime dependency.

## Validation

- `python3 -m pytest -q` (`174 passed, 1 skipped`)
- `flake8 .`
- `npm run typecheck`
- `npm run build`
- reference evaluation smoke: `6/6` runs completed and all three documented artifacts verified
- task-level reviews and final whole-branch review completed
